### PR TITLE
feat: setting UserDto with authenticated

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/dto/AuthenticatedUser.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/dto/AuthenticatedUser.java
@@ -1,0 +1,24 @@
+package com.ssafy.ssafsound.domain.auth.dto;
+
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthenticatedUser {
+    private Long memberId;
+
+    private String memberRole;
+
+    public static AuthenticatedUser of(Member member) {
+        return AuthenticatedUser.builder()
+                .memberId(member.getId())
+                .memberRole(member.getRole().getRoleType())
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.ssafy.ssafsound.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    @NotBlank(message = "코드가 유효하지 않습니다.")
+    private String code;
+
+    @NotBlank(message = "Auth 타입이 유효하지 않습니다.")
+    private String oauthTypeName;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -1,0 +1,33 @@
+package com.ssafy.ssafsound.domain.auth.service.token;
+
+import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedUser;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider implements TokenManager {
+
+    @Override
+    public String createAccessToken(AuthenticatedUser authenticatedUser) {
+        return null;
+    }
+
+    @Override
+    public String createRefreshToken() {
+        return null;
+    }
+
+    @Override
+    public String getPayload() {
+        return null;
+    }
+
+    @Override
+    public AuthenticatedUser getParsedClaims(String token) {
+        return null;
+    }
+
+    @Override
+    public boolean isValid(String token) {
+        return false;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/TokenManager.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/TokenManager.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafsound.domain.auth.service.token;
+
+import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedUser;
+
+public interface TokenManager {
+    String createAccessToken(AuthenticatedUser authenticatedUser);
+
+    String createRefreshToken();
+
+    String getPayload();
+
+    AuthenticatedUser getParsedClaims(String token);
+
+    boolean isValid(String token);
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.ssafy.ssafsound.domain.member.repository;
+
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthIdentifier(String oauthIdentifier);
+}


### PR DESCRIPTION
## Issues

- #15 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 각 도메인에서 token에 대한 인증이 이루어졌을때 인증된 유저 dto에 대한 생성
- 패키지 구조
- 토큰 생성을 위한 인터페이스 및 클래스 추가

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->
전체적으로 dto 구조와 패키지 구조에 대해 리뷰를 해주시면 좋을 것 같습니다!
따끔한 피드백도 좋습니다 📌

예시는 다음과 같습니다.
게시판, 리크루트, 점심 투표 등등
memberId가 필요한 Domain에서는 컨트롤러 부분에서 다음과 같이 사용할 수 있습니다.

```Java
public EnvelopResponse<T> createPost(AuthenticatedUser authenticatedUser) {
...
}
```
## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
