### PR TITLE
feat: AuthenticatedMember Custom Resolver With Interceptor

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -38,6 +38,7 @@ public class AuthController {
         PostMemberReqDto postMemberReqDto = authService.login(createMemberReqDto);
         AuthenticatedMember authenticatedMember = memberService.createMemberByOauthIdentifier(postMemberReqDto);
         CreateMemberTokensResDto createMemberTokensResDto = authService.createToken(authenticatedMember);
+        memberService.saveTokenByMember(authenticatedMember, createMemberTokensResDto.getAccessToken(), createMemberTokensResDto.getRefreshToken());
         Cookie accessTokenCookie = setCookieWithOptions("accessToken", createMemberTokensResDto.getAccessToken());
         Cookie refreshTokenCookie = setCookieWithOptions("refreshToken", createMemberTokensResDto.getRefreshToken());
         response.addCookie(accessTokenCookie);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -50,6 +50,7 @@ public class AuthController {
     public Cookie setCookieWithOptions(String name, String value) {
         Cookie cookie = new Cookie(name, value);
         cookie.setHttpOnly(true);
+        cookie.setMaxAge(2629744);
         cookie.setSecure(true);
         cookie.setPath("/");
         return cookie;

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
@@ -10,7 +10,8 @@ public enum MemberErrorInfo {
     MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
     MEMBER_NOT_FOUND_BY_ID("704", "멤버를 찾을 수 없습니다."),
     AUTH_TOKEN_NOT_FOUND("705", "토큰이 유효하지 않습니다."),
-    AUTH_TOKEN_TIME_OUT("706", "토큰이 만료됐습니다.");
+    AUTH_TOKEN_TIME_OUT("706", "토큰이 만료됐습니다."),
+    AUTH_TOKEN_SERVICE_ERROR("707", "서버에서 토큰을 처리하는 과정에서 문제가 발생했습니다.");
     private String code;
     private String message;
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
@@ -10,7 +10,7 @@ public enum MemberErrorInfo {
     MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
     MEMBER_NOT_FOUND_BY_ID("704", "멤버를 찾을 수 없습니다."),
     AUTH_TOKEN_NOT_FOUND("705", "토큰이 유효하지 않습니다."),
-    AUTH_TOKEN_TIME_OUT("706", "토큰이 만료됐습니다."),
+    AUTH_TOKEN_EXPIRED("706", "토큰이 만료됐습니다."),
     AUTH_TOKEN_SERVICE_ERROR("707", "서버에서 토큰을 처리하는 과정에서 문제가 발생했습니다.");
     private String code;
     private String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
@@ -9,7 +9,8 @@ public enum MemberErrorInfo {
     AUTH_SERVER_PARSING_ERROR("702", "서버에서 파싱하는데 문제가 발생했습니다."),
     MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
     MEMBER_NOT_FOUND_BY_ID("704", "멤버를 찾을 수 없습니다."),
-    AUTH_TOKEN_NOT_FOUND("705", "토큰이 유효하지 않습니다.");
+    AUTH_TOKEN_NOT_FOUND("705", "토큰이 유효하지 않습니다."),
+    AUTH_TOKEN_TIME_OUT("706", "토큰이 만료됐습니다.");
     private String code;
     private String message;
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
@@ -8,7 +8,8 @@ public enum MemberErrorInfo {
     AUTH_SERVER_ERROR("701", "서버에서 소셜 로그인을 제공하는데 문제가 발생했습니다."),
     AUTH_SERVER_PARSING_ERROR("702", "서버에서 파싱하는데 문제가 발생했습니다."),
     MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
-    AUTH_TOKEN_NOT_FOUND("704", "토큰이 유효하지 않습니다.");
+    MEMBER_NOT_FOUND_BY_ID("704", "멤버를 찾을 수 없습니다."),
+    AUTH_TOKEN_NOT_FOUND("705", "토큰이 유효하지 않습니다.");
     private String code;
     private String message;
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/exception/MemberErrorInfo.java
@@ -7,7 +7,8 @@ public enum MemberErrorInfo {
     AUTH_VALUE_NOT_FOUND("700", "code값에 문제가 있거나 Oauth 이름이 잘못되었습니다."),
     AUTH_SERVER_ERROR("701", "서버에서 소셜 로그인을 제공하는데 문제가 발생했습니다."),
     AUTH_SERVER_PARSING_ERROR("702", "서버에서 파싱하는데 문제가 발생했습니다."),
-    MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다.");
+    MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
+    AUTH_TOKEN_NOT_FOUND("704", "토큰이 유효하지 않습니다.");
     private String code;
     private String message;
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -1,6 +1,9 @@
 package com.ssafy.ssafsound.domain.auth.service.token;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -31,7 +34,6 @@ public class JwtTokenProvider {
     public String createAccessToken(AuthenticatedMember authenticatedMember) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + accessTokenValidTime);
-
         return Jwts.builder()
                 .claim("id", authenticatedMember.getMemberId())
                 .claim("role", authenticatedMember.getMemberRole())
@@ -61,6 +63,15 @@ public class JwtTokenProvider {
     }
 
     public boolean isValid(String token) {
-        return false;
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+
+            return claims.getBody().getExpiration().after(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -66,7 +66,7 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_TOKEN_TIME_OUT);
+            throw new AuthException(MemberErrorInfo.AUTH_TOKEN_EXPIRED);
         }
         Long memberId = claims.get("memberId", Long.class);
         String memberRole = claims.get("memberRole", String.class);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/Authentication.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/Authentication.java
@@ -1,0 +1,11 @@
+package com.ssafy.ssafsound.domain.auth.validator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authentication {
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
@@ -1,20 +1,35 @@
 package com.ssafy.ssafsound.domain.auth.validator;
 
+import com.ssafy.ssafsound.domain.auth.exception.AuthException;
+import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
 public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
-    
+    private final JwtTokenProvider jwtTokenProvider;
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return false;
+        return parameter.hasParameterAnnotation(Authentication.class);
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        return null;
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if(Objects.isNull(request)) throw new AuthException(MemberErrorInfo.AUTH_TOKEN_SERVICE_ERROR);
+        String token = AuthorizationExtractor.extractToken("accessToken", request);
+
+        return jwtTokenProvider.getParsedClaims(token);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
@@ -1,7 +1,5 @@
 package com.ssafy.ssafsound.domain.auth.validator;
 
-import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -10,9 +8,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-
 import javax.servlet.http.HttpServletRequest;
-import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -27,7 +23,6 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-        if(Objects.isNull(request)) throw new AuthException(MemberErrorInfo.AUTH_TOKEN_SERVICE_ERROR);
         String token = AuthorizationExtractor.extractToken("accessToken", request);
 
         return jwtTokenProvider.getParsedClaims(token);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
@@ -1,0 +1,20 @@
+package com.ssafy.ssafsound.domain.auth.validator;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+    
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return false;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return null;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
@@ -4,28 +4,18 @@ import com.ssafy.ssafsound.domain.auth.exception.AuthException;
 import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-
-import java.util.Enumeration;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j
 @NoArgsConstructor
 public class AuthorizationExtractor {
-    private static final String COOKIE = "Set-Cookie";
 
     public static String extractToken(String tokeType, HttpServletRequest request) {
-        Enumeration<String> cookies = request.getHeaders(COOKIE);
-        while (cookies.hasMoreElements()) {
-            String cookieInfo = cookies.nextElement();
-            Pattern regex = Pattern.compile(tokeType + "=" + "([^;]+)");
-            Matcher matcher = regex.matcher(cookieInfo);
-            if (matcher.find()) {
-                return matcher.group(1);
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(tokeType)) {
+                return cookie.getValue();
             }
         }
         throw new AuthException(MemberErrorInfo.AUTH_TOKEN_NOT_FOUND);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
@@ -1,0 +1,36 @@
+package com.ssafy.ssafsound.domain.auth.validator;
+
+import lombok.NoArgsConstructor;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Enumeration;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@NoArgsConstructor
+public class AuthorizationExtractor {
+
+    public static final String BEARER_TYPE = "Bearer";
+
+    public static String extractAccessToken(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
+        return extract(headers);
+    }
+
+    private static String extract(Enumeration<String> headers) {
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if ((value.toLowerCase().startsWith(BEARER_TYPE.toLowerCase()))) {
+                String authHeaderValue = value.substring(BEARER_TYPE.length()).trim();
+
+                int commaIndex = authHeaderValue.indexOf(',');
+                if (commaIndex > 0) {
+                    authHeaderValue = authHeaderValue.substring(0, commaIndex);
+                }
+                return authHeaderValue;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
@@ -1,36 +1,33 @@
 package com.ssafy.ssafsound.domain.auth.validator;
 
+import com.ssafy.ssafsound.domain.auth.exception.AuthException;
+import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.servlet.http.HttpServletRequest;
 
 import java.util.Enumeration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+@Slf4j
 @NoArgsConstructor
 public class AuthorizationExtractor {
+    private static final String COOKIE = "Set-Cookie";
 
-    public static final String BEARER_TYPE = "Bearer";
-
-    public static String extractAccessToken(HttpServletRequest request) {
-        Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
-        return extract(headers);
-    }
-
-    private static String extract(Enumeration<String> headers) {
-        while (headers.hasMoreElements()) {
-            String value = headers.nextElement();
-            if ((value.toLowerCase().startsWith(BEARER_TYPE.toLowerCase()))) {
-                String authHeaderValue = value.substring(BEARER_TYPE.length()).trim();
-
-                int commaIndex = authHeaderValue.indexOf(',');
-                if (commaIndex > 0) {
-                    authHeaderValue = authHeaderValue.substring(0, commaIndex);
-                }
-                return authHeaderValue;
+    public static String extractToken(String tokeType, HttpServletRequest request) {
+        Enumeration<String> cookies = request.getHeaders(COOKIE);
+        while (cookies.hasMoreElements()) {
+            String cookieInfo = cookies.nextElement();
+            Pattern regex = Pattern.compile(tokeType + "=" + "([^;]+)");
+            Matcher matcher = regex.matcher(cookieInfo);
+            if (matcher.find()) {
+                return matcher.group(1);
             }
         }
-        return null;
+        throw new AuthException(MemberErrorInfo.AUTH_TOKEN_NOT_FOUND);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberTokenRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberTokenRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafsound.domain.member.repository;
+
+import com.ssafy.ssafsound.domain.member.domain.MemberToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberTokenRepository extends JpaRepository<MemberToken, Long> {
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -1,13 +1,16 @@
 package com.ssafy.ssafsound.domain.member.service;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import com.ssafy.ssafsound.domain.auth.exception.AuthException;
 import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberRole;
+import com.ssafy.ssafsound.domain.member.domain.MemberToken;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
+import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +21,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberRoleRepository memberRoleRepository;
+    private final MemberTokenRepository memberTokenRepository;
 
     @Transactional
      public AuthenticatedMember createMemberByOauthIdentifier(PostMemberReqDto postMemberReqDto) {
@@ -26,11 +30,20 @@ public class MemberService {
 
         member.setMemberRole(memberRole);
         memberRepository.save(member);
-        return AuthenticatedMember.builder()
-                .memberId(member.getId())
-                .memberRole(memberRole.getRoleType())
-                .build();
+        return AuthenticatedMember.of(member);
      }
+
+    @Transactional
+    public void saveTokenByMember(AuthenticatedMember authenticatedMember, String accessToken, String refreshToken) {
+        Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new AuthException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        MemberToken memberToken = MemberToken.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .member(member)
+                .build();
+        memberTokenRepository.save(memberToken);
+    }
 
     public MemberRole findMemberRoleByRoleName(String roleType) {
         return memberRoleRepository.findByRoleType(roleType).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_ROLE_TYPE_NOT_FOUND));

--- a/src/main/java/com/ssafy/ssafsound/global/config/WebMvcConfig.java
+++ b/src/main/java/com/ssafy/ssafsound/global/config/WebMvcConfig.java
@@ -1,18 +1,23 @@
 package com.ssafy.ssafsound.global.config;
 
+import com.ssafy.ssafsound.domain.auth.validator.AuthenticationArgumentResolver;
 import com.ssafy.ssafsound.global.interceptor.AuthInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import java.util.List;
 
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final AuthInterceptor authInterceptor;
+    private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
-    public WebMvcConfig(AuthInterceptor authInterceptor) {
+    public WebMvcConfig(AuthInterceptor authInterceptor, AuthenticationArgumentResolver authenticationArgumentResolver) {
         this.authInterceptor = authInterceptor;
+        this.authenticationArgumentResolver = authenticationArgumentResolver;
     }
 
     @Override
@@ -21,5 +26,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/**")
                 .excludePathPatterns("/auth/callback")
                 .excludePathPatterns("/boards");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationArgumentResolver);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/global/config/WebMvcConfig.java
+++ b/src/main/java/com/ssafy/ssafsound/global/config/WebMvcConfig.java
@@ -1,0 +1,25 @@
+package com.ssafy.ssafsound.global.config;
+
+import com.ssafy.ssafsound.global.interceptor.AuthInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    public WebMvcConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/auth/callback")
+                .excludePathPatterns("/boards");
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
@@ -42,7 +42,7 @@ public class AuthInterceptor implements HandlerInterceptor {
          */
 
         String token =  AuthorizationExtractor.extractToken("accessToken", request);
-        if(isInValidToken(token)) {
+        if(isInvalidToken(token)) {
             throw new AuthException(MemberErrorInfo.AUTH_TOKEN_NOT_FOUND);
         }
         return true;
@@ -81,7 +81,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         return !cookies.hasMoreElements();
     }
 
-    private boolean isInValidToken(String token) {
+    private boolean isInvalidToken(String token) {
         return !jwtTokenProvider.isValid(token);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
@@ -42,9 +42,8 @@ public class AuthInterceptor implements HandlerInterceptor {
          */
 
         String token =  AuthorizationExtractor.extractToken("accessToken", request);
-
         if(isInValidToken(token)) {
-            return false;
+            throw new AuthException(MemberErrorInfo.AUTH_TOKEN_NOT_FOUND);
         }
         return true;
     }

--- a/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
@@ -1,0 +1,81 @@
+package com.ssafy.ssafsound.global.interceptor;
+
+import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
+import com.ssafy.ssafsound.domain.auth.validator.AuthorizationExtractor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Objects;
+
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
+        if (isGetMethodWithRecruitUri(request) || isGetMethodWithAuthUri(request)
+                || isGetMethodWithCommentsUri(request) || isGetMethodWithLunchPollUri(request) || isGetMethodWithMetaUri(request)
+                || isGetMethodWithMembersUri(request) || isGetMethodWithPostsUri(request)) {
+            return true;
+        }
+
+        if (isNotExistHeader(request)) {
+            return false;
+        }
+
+        String token =  AuthorizationExtractor.extractAccessToken(request);
+
+        if(isInValidToken(token)) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isGetMethodWithRecruitUri(HttpServletRequest request) {
+        return request.getRequestURI().contains("/recruits") && request.getMethod().equalsIgnoreCase("GET");
+    }
+
+    private boolean isGetMethodWithAuthUri(HttpServletRequest request) {
+        return request.getRequestURI().contains("/auth") && request.getMethod().equalsIgnoreCase("GET");
+    }
+
+    private boolean isGetMethodWithCommentsUri(HttpServletRequest request) {
+        return request.getRequestURI().contains("/comments") && request.getMethod().equalsIgnoreCase("GET");
+    }
+
+    private boolean isGetMethodWithLunchPollUri(HttpServletRequest request) {
+        return request.getRequestURI().contains("/lunch") && request.getMethod().equalsIgnoreCase("GET");
+    }
+
+    private boolean isGetMethodWithMetaUri(HttpServletRequest request) {
+        return request.getRequestURI().contains("/meta") && request.getMethod().equalsIgnoreCase("GET");
+    }
+
+    private boolean isGetMethodWithMembersUri(HttpServletRequest request) {
+        return request.getRequestURI().contains("/members") && request.getMethod().equalsIgnoreCase("GET");
+    }
+
+    private boolean isGetMethodWithPostsUri(HttpServletRequest request) {
+        return request.getRequestURI().contains("/posts") && request.getMethod().equalsIgnoreCase("GET");
+    }
+
+    private boolean isNotExistHeader(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        return Objects.isNull(authorizationHeader);
+    }
+
+    private boolean isInValidToken(String token) {
+        return !jwtTokenProvider.isValid(token);
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
@@ -9,9 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Enumeration;
 
 
 @Slf4j
@@ -77,8 +77,8 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     private boolean isNotExistCookie(HttpServletRequest request) {
-        Enumeration<String> cookies = request.getHeaders(COOKIE);
-        return !cookies.hasMoreElements();
+        Cookie[] cookies = request.getCookies();
+        return !(cookies.length > 0);
     }
 
     private boolean isInvalidToken(String token) {


### PR DESCRIPTION
## Issues

- #49 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- Client의 요청에서 Token은 헤더에 담기지 않습니다. Http Only Secure Cookie를 통해 클라이언트에게 전달되며, 해당 쿠키를 통해 클라이언트는 서버에 전달합니다.
- 우리 API에서는  recruit, post, lunch, auth, comments, meta 와 관련된 Domain에서 GET 요청에 대해 AcccessToken이 필요하지 않다고 판단해서 인터셉터에서 통과될 수 있도록 적용했습니다.

```Java
@Component
@RequiredArgsConstructor
public class AuthInterceptor implements HandlerInterceptor {
    private final JwtTokenProvider jwtTokenProvider;

    @Override
    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
        if (CorsUtils.isPreFlightRequest(request)) {
            return true;
        }

        if (isGetMethodWithRecruitUri(request) || isGetMethodWithAuthUri(request)
                || isGetMethodWithCommentsUri(request) || isGetMethodWithLunchPollUri(request) || isGetMethodWithMetaUri(request)
                || isGetMethodWithMembersUri(request) || isGetMethodWithPostsUri(request)) {
            return true;
        } ...
```

전체 코드에서 확인해주시고 의견 있으시면 리뷰를 통해 지속적으로 Pull Request에서 반영하겠습니다.
- Member 저장 시, 토큰도 저장하도록 추가했습니다.
- WebMvcConfig 에서 인터셉터와 리졸버를 추가했습니다.

```Java
public EnvelopeResponse<PostLunchPollResDto> postLunchPoll(@Authentication AuthenticationMember user) {
...
}
```
와 같이 애노테이션을 통해 유저 정보를 가져올 수 있습니다.

1. 토큰이 유효하지 않은경우
2. 토큰이 만료 됐을경우

재발급 요청을 하는 예외 처리를 하도록 명세했습니다.


재발급 요청에도 유효하지 않거나 만료됐다면 -> 다시 로그인을 하도록 하는 플로우를 가지고 있습니다.
<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
