### PR TITLE
feat: member logout with reIssue token

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.auth.controller;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import com.ssafy.ssafsound.domain.auth.dto.CreateAccessTokenResDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberReqDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberTokensResDto;
 import com.ssafy.ssafsound.domain.auth.service.AuthService;
@@ -49,10 +50,14 @@ public class AuthController {
     }
 
     @GetMapping("/reissue")
-    public EnvelopeResponse<CreateMemberTokensResDto> reissue(HttpServletRequest request) {
+    public EnvelopeResponse<CreateAccessTokenResDto> reIssue(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = AuthorizationExtractor.extractToken("refreshToken", request);
-        authService.validateRefreshToken(refreshToken);
-        return EnvelopeResponse.<CreateMemberTokensResDto>builder()
+        Long memberId = authService.validateRefreshToken(refreshToken);
+        CreateAccessTokenResDto createAccessTokenResDto = authService.reIssueAccessToken(memberId);
+        Cookie accessTokenCookie = setCookieWithOptions("accessToken", createAccessTokenResDto.getAccessToken());
+        response.addCookie(accessTokenCookie);
+        return EnvelopeResponse.<CreateAccessTokenResDto>builder()
+                .data(createAccessTokenResDto)
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -53,7 +53,9 @@ public class AuthController {
     @GetMapping("/logout")
     public EnvelopeResponse logout(HttpServletRequest request, HttpServletResponse response) {
         Cookie[] cookies = request.getCookies();
-        if (!Objects.nonNull(cookies)) {
+
+        if (Objects.nonNull(cookies)) {
+            authService.deleteTokensByCookie(cookies);
             Cookie accessTokenCookie = deleteCookie("accessToken", null);
             Cookie refreshTokenCookie = deleteCookie("refreshToken", null);
             response.addCookie(accessTokenCookie);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.ssafy.ssafsound.domain.auth.controller;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
-import com.ssafy.ssafsound.domain.auth.dto.CreateAccessTokenResDto;
+import com.ssafy.ssafsound.domain.auth.dto.CreateMemberAccessTokenResDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberReqDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberTokensResDto;
 import com.ssafy.ssafsound.domain.auth.service.AuthService;
@@ -47,14 +47,14 @@ public class AuthController {
     }
 
     @GetMapping("/reissue")
-    public EnvelopeResponse<CreateAccessTokenResDto> reIssue(HttpServletRequest request, HttpServletResponse response) {
+    public EnvelopeResponse<CreateMemberAccessTokenResDto> reissue(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = AuthorizationExtractor.extractToken("refreshToken", request);
         Long memberId = authService.validateRefreshToken(refreshToken);
-        CreateAccessTokenResDto createAccessTokenResDto = authService.reIssueAccessToken(memberId);
-        Cookie accessTokenCookie = setCookieWithOptions("accessToken", createAccessTokenResDto.getAccessToken());
+        CreateMemberAccessTokenResDto createMemberAccessTokenResDto = authService.reissueAccessToken(memberId);
+        Cookie accessTokenCookie = setCookieWithOptions("accessToken", createMemberAccessTokenResDto.getAccessToken());
         response.addCookie(accessTokenCookie);
-        return EnvelopeResponse.<CreateAccessTokenResDto>builder()
-                .data(createAccessTokenResDto)
+        return EnvelopeResponse.<CreateMemberAccessTokenResDto>builder()
+                .data(createMemberAccessTokenResDto)
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -41,10 +41,7 @@ public class AuthController {
 
         if (Objects.nonNull(cookies)) {
             authService.deleteTokensByCookie(cookies);
-            Cookie accessTokenCookie = deleteCookie("accessToken", null);
-            Cookie refreshTokenCookie = deleteCookie("refreshToken", null);
-            response.addCookie(accessTokenCookie);
-            response.addCookie(refreshTokenCookie);
+            setResponseWithCookies(response, null, null);
         }
         return EnvelopeResponse.builder().build();
     }
@@ -69,13 +66,23 @@ public class AuthController {
         AuthenticatedMember authenticatedMember = memberService.createMemberByOauthIdentifier(postMemberReqDto);
         CreateMemberTokensResDto createMemberTokensResDto = authService.createToken(authenticatedMember);
         memberService.saveTokenByMember(authenticatedMember, createMemberTokensResDto.getAccessToken(), createMemberTokensResDto.getRefreshToken());
-        Cookie accessTokenCookie = setCookieWithOptions("accessToken", createMemberTokensResDto.getAccessToken());
-        Cookie refreshTokenCookie = setCookieWithOptions("refreshToken", createMemberTokensResDto.getRefreshToken());
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+        setResponseWithCookies(response, createMemberTokensResDto.getAccessToken(), createMemberTokensResDto.getRefreshToken());
         return EnvelopeResponse.<CreateMemberTokensResDto>builder()
                 .data(createMemberTokensResDto)
                 .build();
+    }
+
+    public void setResponseWithCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+        Cookie accessTokenCookie, refreshTokenCookie;
+        if (accessToken == null && refreshToken == null) {
+            accessTokenCookie = deleteCookie("accessToken", null);
+            refreshTokenCookie = deleteCookie("refreshToken", null);
+        } else {
+            accessTokenCookie = setCookieWithOptions("accessToken", accessToken);
+            refreshTokenCookie = setCookieWithOptions("refreshToken", refreshToken);
+        }
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
     }
 
     public Cookie setCookieWithOptions(String name, String value) {

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -10,8 +10,10 @@ import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/auth")
@@ -48,10 +50,31 @@ public class AuthController {
                 .build();
     }
 
+    @GetMapping("/logout")
+    public EnvelopeResponse logout(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+        if (!Objects.nonNull(cookies)) {
+            Cookie accessTokenCookie = deleteCookie("accessToken", null);
+            Cookie refreshTokenCookie = deleteCookie("refreshToken", null);
+            response.addCookie(accessTokenCookie);
+            response.addCookie(refreshTokenCookie);
+        }
+        return EnvelopeResponse.builder().build();
+    }
+
     public Cookie setCookieWithOptions(String name, String value) {
         Cookie cookie = new Cookie(name, value);
         cookie.setHttpOnly(true);
         cookie.setMaxAge(2629744);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        return cookie;
+    }
+
+    public Cookie deleteCookie(String name, String value) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
         cookie.setSecure(true);
         cookie.setPath("/");
         return cookie;

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberReqDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberTokensResDto;
 import com.ssafy.ssafsound.domain.auth.service.AuthService;
+import com.ssafy.ssafsound.domain.auth.validator.AuthorizationExtractor;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import com.ssafy.ssafsound.domain.member.service.MemberService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
@@ -33,6 +34,28 @@ public class AuthController {
         authService.sendRedirectURL(oauthName, response);
     }
 
+    @GetMapping("/logout")
+    public EnvelopeResponse logout(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+
+        if (Objects.nonNull(cookies)) {
+            authService.deleteTokensByCookie(cookies);
+            Cookie accessTokenCookie = deleteCookie("accessToken", null);
+            Cookie refreshTokenCookie = deleteCookie("refreshToken", null);
+            response.addCookie(accessTokenCookie);
+            response.addCookie(refreshTokenCookie);
+        }
+        return EnvelopeResponse.builder().build();
+    }
+
+    @GetMapping("/reissue")
+    public EnvelopeResponse<CreateMemberTokensResDto> reissue(HttpServletRequest request) {
+        String refreshToken = AuthorizationExtractor.extractToken("refreshToken", request);
+        authService.validateRefreshToken(refreshToken);
+        return EnvelopeResponse.<CreateMemberTokensResDto>builder()
+                .build();
+    }
+
     @PostMapping("/callback")
     public EnvelopeResponse<CreateMemberTokensResDto> login(
             @Valid @RequestBody CreateMemberReqDto createMemberReqDto,
@@ -48,20 +71,6 @@ public class AuthController {
         return EnvelopeResponse.<CreateMemberTokensResDto>builder()
                 .data(createMemberTokensResDto)
                 .build();
-    }
-
-    @GetMapping("/logout")
-    public EnvelopeResponse logout(HttpServletRequest request, HttpServletResponse response) {
-        Cookie[] cookies = request.getCookies();
-
-        if (Objects.nonNull(cookies)) {
-            authService.deleteTokensByCookie(cookies);
-            Cookie accessTokenCookie = deleteCookie("accessToken", null);
-            Cookie refreshTokenCookie = deleteCookie("refreshToken", null);
-            response.addCookie(accessTokenCookie);
-            response.addCookie(refreshTokenCookie);
-        }
-        return EnvelopeResponse.builder().build();
     }
 
     public Cookie setCookieWithOptions(String name, String value) {

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/dto/CreateAccessTokenResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/dto/CreateAccessTokenResDto.java
@@ -1,0 +1,16 @@
+package com.ssafy.ssafsound.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateAccessTokenResDto {
+    private String accessToken;
+
+    public static CreateAccessTokenResDto of(String accessToken) {
+        return CreateAccessTokenResDto.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/dto/CreateMemberAccessTokenResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/dto/CreateMemberAccessTokenResDto.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class CreateAccessTokenResDto {
+public class CreateMemberAccessTokenResDto {
     private String accessToken;
 
-    public static CreateAccessTokenResDto of(String accessToken) {
-        return CreateAccessTokenResDto.builder()
+    public static CreateMemberAccessTokenResDto of(String accessToken) {
+        return CreateMemberAccessTokenResDto.builder()
                 .accessToken(accessToken)
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/exception/AuthErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/exception/AuthErrorInfo.java
@@ -3,19 +3,18 @@ package com.ssafy.ssafsound.domain.auth.exception;
 import lombok.Getter;
 
 @Getter
-public enum MemberErrorInfo {
+public enum AuthErrorInfo {
     AUTH_VALUE_NOT_FOUND("700", "code값에 문제가 있거나 Oauth 이름이 잘못되었습니다."),
     AUTH_SERVER_ERROR("701", "서버에서 소셜 로그인을 제공하는데 문제가 발생했습니다."),
     AUTH_SERVER_PARSING_ERROR("702", "서버에서 파싱하는데 문제가 발생했습니다."),
-    MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
-    MEMBER_NOT_FOUND_BY_ID("704", "멤버를 찾을 수 없습니다."),
-    AUTH_TOKEN_NOT_FOUND("705", "토큰이 유효하지 않습니다."),
+    AUTH_TOKEN_INVALID("705", "토큰이 유효하지 않습니다."),
     AUTH_TOKEN_EXPIRED("706", "토큰이 만료됐습니다."),
     AUTH_TOKEN_SERVICE_ERROR("707", "서버에서 토큰을 처리하는 과정에서 문제가 발생했습니다.");
-    private String code;
-    private String message;
 
-    MemberErrorInfo(String code, String message) {
+    private final String code;
+    private final String message;
+
+    AuthErrorInfo(String code, String message) {
         this.code = code;
         this.message = message;
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/exception/AuthException.java
@@ -8,5 +8,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AuthException extends RuntimeException {
-    private MemberErrorInfo info;
+    private AuthErrorInfo info;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService {
 
     public PostMemberReqDto login(CreateMemberReqDto createMemberReqDto) {
         OauthProvider oauthProvider = oauthProviderFactory.from(createMemberReqDto.getOauthName());
-        String accessToken = oauthProvider.getOauthAccessToken(createMemberReqDto.getCode());;
+        String accessToken = oauthProvider.getOauthAccessToken(createMemberReqDto.getCode());
         return oauthProvider.getMemberOauthIdentifier(accessToken, createMemberReqDto.getOauthName());
     }
 
@@ -63,5 +63,10 @@ public class AuthService {
                 memberTokenRepository.deleteById(authenticatedMember.getMemberId());
             }
         }
+    }
+
+    @Transactional(readOnly = true)
+    public void validateRefreshToken(String refreshToken) {
+
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -13,7 +13,6 @@ import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
@@ -50,7 +49,7 @@ public class AuthService {
     public CreateMemberTokensResDto createToken(AuthenticatedMember authenticatedMember) {
         return CreateMemberTokensResDto.builder()
                 .accessToken(jwtTokenProvider.createAccessToken(authenticatedMember))
-                .refreshToken(jwtTokenProvider.createRefreshToken())
+                .refreshToken(jwtTokenProvider.createRefreshToken(authenticatedMember))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -4,12 +4,13 @@ import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberReqDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberTokensResDto;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.auth.service.oauth.OauthProvider;
 import com.ssafy.ssafsound.domain.auth.service.oauth.OauthProviderFactory;
 import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
 import com.ssafy.ssafsound.domain.member.domain.MemberToken;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
+import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +39,7 @@ public class AuthService {
             String redirectURL = oauthProvider.getOauthUrl();
             response.sendRedirect(redirectURL);
         } catch (Exception e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_ERROR);
         }
     }
 
@@ -69,8 +70,8 @@ public class AuthService {
     @Transactional(readOnly = true)
     public void validateRefreshToken(String refreshToken) {
         Long memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
-        MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException());
-        if(isNotEqualRefreshToken(refreshToken, memberToken.getRefreshToken())) throw new AuthException();
+        MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_TOKEN_NOT_FOUND));
+        if(isNotEqualRefreshToken(refreshToken, memberToken.getRefreshToken())) throw new AuthException(AuthErrorInfo.AUTH_TOKEN_INVALID);
     }
 
     public boolean isNotEqualRefreshToken(String refreshTokenByCookie, String refreshTokenBySaved) {

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.ssafy.ssafsound.domain.auth.service;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
-import com.ssafy.ssafsound.domain.auth.dto.CreateAccessTokenResDto;
+import com.ssafy.ssafsound.domain.auth.dto.CreateMemberAccessTokenResDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberReqDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberTokensResDto;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
@@ -78,13 +78,13 @@ public class AuthService {
     }
 
     @Transactional
-    public CreateAccessTokenResDto reIssueAccessToken(Long memberId) {
+    public CreateMemberAccessTokenResDto reissueAccessToken(Long memberId) {
         MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_TOKEN_NOT_FOUND));
         Member member = memberToken.getMember();
         String accessToken = jwtTokenProvider.createAccessToken(AuthenticatedMember.of(member));
         memberToken.changeAccessTokenByRefreshToken(accessToken);
         memberTokenRepository.save(memberToken);
-        return CreateAccessTokenResDto.of(accessToken);
+        return CreateMemberAccessTokenResDto.of(accessToken);
     }
 
     public boolean isNotEqualRefreshToken(String refreshTokenByCookie, String refreshTokenBySaved) {

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -8,7 +8,9 @@ import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.auth.service.oauth.OauthProvider;
 import com.ssafy.ssafsound.domain.auth.service.oauth.OauthProviderFactory;
 import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
+import com.ssafy.ssafsound.domain.member.domain.MemberToken;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
+import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -66,6 +68,12 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public void validateRefreshToken(String refreshToken) {
+        Long memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
+        MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException());
+        if(isNotEqualRefreshToken(refreshToken, memberToken.getRefreshToken())) throw new AuthException();
+    }
 
+    public boolean isNotEqualRefreshToken(String refreshTokenByCookie, String refreshTokenBySaved) {
+        return !refreshTokenByCookie.equals(refreshTokenBySaved);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -82,7 +82,7 @@ public class AuthService {
         MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_TOKEN_NOT_FOUND));
         Member member = memberToken.getMember();
         String accessToken = jwtTokenProvider.createAccessToken(AuthenticatedMember.of(member));
-        memberToken.changeByRefreshToken(accessToken);
+        memberToken.changeAccessTokenByRefreshToken(accessToken);
         memberTokenRepository.save(memberToken);
         return CreateAccessTokenResDto.of(accessToken);
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -15,13 +15,10 @@ import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
-@Slf4j
 @Service
 public class AuthService {
 
@@ -59,14 +56,15 @@ public class AuthService {
     }
 
     @Transactional
-    public void deleteTokensByCookie(Cookie[] cookies) {
-        for (Cookie cookie : cookies) {
-            String token = cookie.getValue();
-            if (jwtTokenProvider.isValid(token) && cookie.getName().equals("accessToken")) {
-                AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaims(token);
-                memberTokenRepository.deleteById(authenticatedMember.getMemberId());
-            }
+    public void deleteTokens(String accessToken, String refreshToken) {
+        Long memberId = null;
+        if (jwtTokenProvider.isValid(accessToken)) {
+            AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaims(accessToken);
+            memberId = authenticatedMember.getMemberId();
+        } else if (jwtTokenProvider.isValid(refreshToken)) {
+            memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
         }
+        if(memberId != null) memberTokenRepository.deleteById(memberId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.auth.service;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import com.ssafy.ssafsound.domain.auth.dto.CreateAccessTokenResDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberReqDto;
 import com.ssafy.ssafsound.domain.auth.dto.CreateMemberTokensResDto;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
@@ -8,6 +9,7 @@ import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.auth.service.oauth.OauthProvider;
 import com.ssafy.ssafsound.domain.auth.service.oauth.OauthProviderFactory;
 import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
+import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberToken;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
@@ -68,10 +70,21 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public void validateRefreshToken(String refreshToken) {
+    public Long validateRefreshToken(String refreshToken) {
         Long memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
         MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_TOKEN_NOT_FOUND));
         if(isNotEqualRefreshToken(refreshToken, memberToken.getRefreshToken())) throw new AuthException(AuthErrorInfo.AUTH_TOKEN_INVALID);
+        return memberId;
+    }
+
+    @Transactional
+    public CreateAccessTokenResDto reIssueAccessToken(Long memberId) {
+        MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_TOKEN_NOT_FOUND));
+        Member member = memberToken.getMember();
+        String accessToken = jwtTokenProvider.createAccessToken(AuthenticatedMember.of(member));
+        memberToken.changeByRefreshToken(accessToken);
+        memberTokenRepository.save(memberToken);
+        return CreateAccessTokenResDto.of(accessToken);
     }
 
     public boolean isNotEqualRefreshToken(String refreshTokenByCookie, String refreshTokenBySaved) {

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/CookieProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/CookieProvider.java
@@ -1,0 +1,43 @@
+package com.ssafy.ssafsound.domain.auth.service;
+
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@NoArgsConstructor
+public class CookieProvider {
+
+    public Cookie setCookieWithOptions(String name, String value) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(2629744);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        return cookie;
+    }
+
+    public void setResponseWithCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+        Cookie accessTokenCookie, refreshTokenCookie;
+        if (accessToken == null && refreshToken == null) {
+            accessTokenCookie = deleteCookie("accessToken", null);
+            refreshTokenCookie = deleteCookie("refreshToken", null);
+        } else {
+            accessTokenCookie = setCookieWithOptions("accessToken", accessToken);
+            refreshTokenCookie = setCookieWithOptions("refreshToken", refreshToken);
+        }
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
+    }
+
+    public Cookie deleteCookie(String name, String value) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        return cookie;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/GithubOauthProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/GithubOauthProvider.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,7 +60,7 @@ public class GithubOauthProvider implements OauthProvider {
             if (apiResponse.getBody() == null) throw new AuthException();
             return parsingAccessToken(apiResponse.getBody());
         } catch (RestClientException | AuthException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_ERROR);
         }
     }
 
@@ -79,9 +79,9 @@ public class GithubOauthProvider implements OauthProvider {
                     .oauthName(oauthName)
                     .build();
         } catch (RestClientException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_ERROR);
         } catch (JsonProcessingException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_PARSING_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_PARSING_ERROR);
         }
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/GithubOauthProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/GithubOauthProvider.java
@@ -114,6 +114,6 @@ public class GithubOauthProvider implements OauthProvider {
     public String parsingValue(String response, String key) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> jsonMap = objectMapper.readValue(response, new TypeReference<>() {});
-        return (String) jsonMap.get(key);
+        return String.valueOf(jsonMap.get(key));
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/GoogleOauthProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/GoogleOauthProvider.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,9 +62,9 @@ public class GoogleOauthProvider implements OauthProvider {
             ResponseEntity<String> apiResponse = restTemplate.postForEntity(GOOGLE_TOKEN_URL, restRequest, String.class);
             return parsingValue(apiResponse.getBody(), "access_token");
         } catch (RestClientException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_ERROR);
         } catch (JsonProcessingException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_PARSING_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_PARSING_ERROR);
         }
     }
 
@@ -81,9 +81,9 @@ public class GoogleOauthProvider implements OauthProvider {
                     .oauthName(oauthName)
                     .build();
         } catch (RestClientException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_ERROR);
         } catch (JsonProcessingException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_PARSING_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_PARSING_ERROR);
         }
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/KakaoOauthProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/KakaoOauthProvider.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,7 +60,7 @@ public class KakaoOauthProvider implements OauthProvider {
             ResponseEntity<String> apiResponse = restTemplate.postForEntity(KAKAO_TOKEN_URL, restRequest, String.class);
             return parsingValue(apiResponse.getBody(), "access_token");
         } catch (RestClientException | JsonProcessingException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_ERROR);
         }
     }
 
@@ -77,7 +77,7 @@ public class KakaoOauthProvider implements OauthProvider {
                     .oauthName(oauthName)
                     .build();
         } catch (RestClientException | JsonProcessingException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_SERVER_ERROR);
+            throw new AuthException(AuthErrorInfo.AUTH_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/OauthProviderFactory.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/oauth/OauthProviderFactory.java
@@ -1,7 +1,7 @@
 package com.ssafy.ssafsound.domain.auth.service.oauth;
 
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.member.domain.OAuthType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -27,7 +27,7 @@ public class OauthProviderFactory {
 
     public OauthProvider from(String oAuthType) {
         OAuthType enumType = Arrays.stream(OAuthType.values()).filter(type -> type.isEqual(oAuthType)).findFirst().orElse(null);
-        if(enumType == null) throw new AuthException(MemberErrorInfo.AUTH_VALUE_NOT_FOUND);
+        if(enumType == null) throw new AuthException(AuthErrorInfo.AUTH_VALUE_NOT_FOUND);
         return this.oauthProviderMap.get(enumType);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -42,11 +42,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken() {
+    public String createRefreshToken(AuthenticatedMember authenticatedMember) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + refreshTokenValidTime);
 
         return Jwts.builder()
+                .claim("memberId", authenticatedMember.getMemberId())
                 .setIssuedAt(now)
                 .setExpiration(validity)
                 .signWith(key)

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -2,7 +2,7 @@ package com.ssafy.ssafsound.domain.auth.service.token;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import io.jsonwebtoken.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -63,7 +63,7 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_TOKEN_EXPIRED);
+            throw new AuthException(AuthErrorInfo.AUTH_TOKEN_EXPIRED);
         }
         return claims.get("memberId", Long.class);
     }
@@ -77,7 +77,7 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException e) {
-            throw new AuthException(MemberErrorInfo.AUTH_TOKEN_EXPIRED);
+            throw new AuthException(AuthErrorInfo.AUTH_TOKEN_EXPIRED);
         }
         Long memberId = claims.get("memberId", Long.class);
         String memberRole = claims.get("memberRole", String.class);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -54,8 +54,18 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String getPayload() {
-        return null;
+    public Long getMemberIdByRefreshToken(String token) {
+        Claims claims;
+        try {
+            claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(MemberErrorInfo.AUTH_TOKEN_EXPIRED);
+        }
+        return claims.get("memberId", Long.class);
     }
 
     public AuthenticatedMember getParsedClaims(String token) {

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
@@ -1,7 +1,7 @@
 package com.ssafy.ssafsound.domain.auth.validator;
 
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import javax.servlet.http.Cookie;
@@ -18,6 +18,6 @@ public class AuthorizationExtractor {
                 return cookie.getValue();
             }
         }
-        throw new AuthException(MemberErrorInfo.AUTH_TOKEN_NOT_FOUND);
+        throw new AuthException(AuthErrorInfo.AUTH_TOKEN_INVALID);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberToken.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberToken.java
@@ -28,4 +28,8 @@ public class MemberToken {
     @MapsId
     @JoinColumn(name="member_id")
     private Member member;
+
+    public void changeByRefreshToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberToken.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberToken.java
@@ -29,7 +29,15 @@ public class MemberToken {
     @JoinColumn(name="member_id")
     private Member member;
 
-    public void changeByRefreshToken(String accessToken) {
+    public void changeAccessTokenByRefreshToken(String accessToken) {
         this.accessToken = accessToken;
+    }
+
+    public void changeAccessTokenByLogin(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void changeRefreshTokenByLogin(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
@@ -7,7 +7,8 @@ public enum MemberErrorInfo {
 
     MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
     MEMBER_NOT_FOUND_BY_ID("704", "멤버를 찾을 수 없습니다."),
-    MEMBER_TOKEN_NOT_FOUND("708", "멤버 ID로 토큰을 찾을 수 없습니다.");
+    MEMBER_TOKEN_NOT_FOUND("708", "멤버 ID로 토큰을 찾을 수 없습니다."),
+    MEMBER_OAUTH_NOT_FOUND("709", "소셜 로그인에 문제가 발생했습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
@@ -1,0 +1,19 @@
+package com.ssafy.ssafsound.domain.member.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberErrorInfo {
+
+    MEMBER_ROLE_TYPE_NOT_FOUND("703", "멤버 권한을 찾을 수 없는 문제가 발생했습니다."),
+    MEMBER_NOT_FOUND_BY_ID("704", "멤버를 찾을 수 없습니다."),
+    MEMBER_TOKEN_NOT_FOUND("708", "멤버 ID로 토큰을 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+
+    MemberErrorInfo(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberException.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberException.java
@@ -1,6 +1,6 @@
 package com.ssafy.ssafsound.domain.member.exception;
 
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -2,11 +2,12 @@ package com.ssafy.ssafsound.domain.member.service;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberRole;
 import com.ssafy.ssafsound.domain.member.domain.MemberToken;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
+import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
@@ -35,7 +36,7 @@ public class MemberService {
 
     @Transactional
     public void saveTokenByMember(AuthenticatedMember authenticatedMember, String accessToken, String refreshToken) {
-        Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new AuthException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+        Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
         MemberToken memberToken = MemberToken.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -27,13 +27,13 @@ public class MemberService {
 
     @Transactional
      public AuthenticatedMember createMemberByOauthIdentifier(PostMemberReqDto postMemberReqDto) {
-        MemberRole memberRole = findMemberRoleByRoleName("user");
         Optional<Member> optionalMember = memberRepository.findByOauthIdentifier(postMemberReqDto.getOauthIdentifier());
         Member member;
         if (optionalMember.isPresent()) {
              member = optionalMember.get();
              if(isInvalidOauthLogin(member, postMemberReqDto)) throw new MemberException(MemberErrorInfo.MEMBER_OAUTH_NOT_FOUND);
         } else {
+            MemberRole memberRole = findMemberRoleByRoleName("user");
             member = postMemberReqDto.createMember();
             member.setMemberRole(memberRole);
             memberRepository.save(member);

--- a/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/ssafy/ssafsound/global/interceptor/AuthInterceptor.java
@@ -1,7 +1,7 @@
 package com.ssafy.ssafsound.global.interceptor;
 
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
-import com.ssafy.ssafsound.domain.auth.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
 import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
 import com.ssafy.ssafsound.domain.auth.validator.AuthorizationExtractor;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +66,6 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     public void validToken(String token) {
-        if(!jwtTokenProvider.isValid(token)) throw new AuthException(MemberErrorInfo.AUTH_TOKEN_EXPIRED);
+        if(!jwtTokenProvider.isValid(token)) throw new AuthException(AuthErrorInfo.AUTH_TOKEN_EXPIRED);
     }
 }


### PR DESCRIPTION
## Issues

- #58 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 로그아웃 시, 쿠키를 더이상 사용하지 못하도록 null value 설정과 함께 setMaxAge(0); 으로 로직을 제공하고 있습니다.
   - 토큰이 유효한 상황에서 로그아웃을 시도한다면 데이터베이스의 존재하는 토큰도 함께 제거됩니다.
- 토큰 재발급 요청 시
  1. 쿠키가 존재하지 않다면 재발급을 해줄 수 없습니다.
  2. Refresh Token이 만료됐다면 재발급을 해줄 수 없습니다.
  3. 만료는 되지 않았는데 해당 리프레시 토큰과 데이터베이스 존재하는 리프레시 토큰과 비교 후, 일치하지 않다면 재발급을 해줄 수 없습니다.
  4. 재발급에 성공했다면, 데이터베이스에 존재하는 토큰이 갱신되고 쿠키에 담아 전송됩니다.
- 회원 가입을 했었던 유저가 로그인을 시도할 경우
 1. Oauth의 고유 Identifier에 대한 검증과 OauthType에 대한 검증 로직이 추가됐습니다.
 2. 기존에 가지고 있던 정보로 로그인을 다시 시도했을 경우, Member Token 조회와 함께 Access Token과 Refresh Token이 변경됩니다.
---

MemberErrorInfo와 AuthErrorInfo에 대한 분리 로직이 중간에 들어가있습니다. 커밋 기록을 보며 혼동이 올 수 있는데 양해 부탁드립니다.
다음에는 분리해서 진행하겠습니다.


회원가입을 한 유저가 로그인을 시도했을때 검증 로직을 구현하면서 의문점이 들었습니다.
기존 방식에서 Github으로 로그인 할 시, Github Name에 대한 unique Identifier가 설정되어 있었는데 유저가 github id를 바꾸면 로직에 문제가 발생한다는 것을 깨달았습니다.

따라서 unique Idnetifier 추출에 대한 값을 변경했습니다.

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
