### PR TITLE
feat: 등록자 리크루팅 신청 목록 조회 기능

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafsound.domain.recruitapplication.controller;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitApplicationsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitParticipantsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.PostRecruitApplicationReqDto;
 import com.ssafy.ssafsound.domain.recruitapplication.service.RecruitApplicationService;
@@ -51,6 +52,13 @@ public class RecruitApplicationController {
     public EnvelopeResponse<GetRecruitParticipantsResDto> getRecruitParticipants(@PathVariable Long recruitId) {
         return EnvelopeResponse.<GetRecruitParticipantsResDto>builder()
                 .data(recruitApplicationService.getRecruitParticipants(recruitId))
+                .build();
+    }
+
+    @GetMapping("/recruit-applications")
+    public EnvelopeResponse<GetRecruitApplicationsResDto> getRecruitApplications(@RequestParam Long recruitId, AuthenticatedMember authenticatedMember) {
+        return EnvelopeResponse.<GetRecruitApplicationsResDto>builder()
+                .data(recruitApplicationService.getRecruitApplications(recruitId, authenticatedMember.getMemberId()))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -58,7 +58,7 @@ public class RecruitApplicationController {
     @GetMapping("/recruit-applications")
     public EnvelopeResponse<GetRecruitApplicationsResDto> getRecruitApplications(@RequestParam Long recruitId, AuthenticatedMember authenticatedMember) {
         return EnvelopeResponse.<GetRecruitApplicationsResDto>builder()
-                .data(recruitApplicationService.getRecruitApplications(recruitId, authenticatedMember.getMemberId()))
+                .data(recruitApplicationService.getRecruitApplications(recruitId, 1L))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -61,4 +61,11 @@ public class RecruitApplicationController {
                 .data(recruitApplicationService.getRecruitApplications(recruitId, authenticatedMember.getMemberId()))
                 .build();
     }
+
+    @PostMapping("/recruit-applications/{recruitApplicationId}/like")
+    public EnvelopeResponse<Void> toggleRecruitApplicationLike(@PathVariable Long recruitApplicationId, AuthenticatedMember authenticatedMember) {
+        recruitApplicationService.toggleRecruitApplicationLike(recruitApplicationId, authenticatedMember.getMemberId());
+        return EnvelopeResponse.<Void>builder()
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -5,6 +5,7 @@ import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitApplicationsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitParticipantsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.PostRecruitApplicationReqDto;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
 import com.ssafy.ssafsound.domain.recruitapplication.service.RecruitApplicationService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +67,13 @@ public class RecruitApplicationController {
     public EnvelopeResponse<Void> toggleRecruitApplicationLike(@PathVariable Long recruitApplicationId, AuthenticatedMember authenticatedMember) {
         recruitApplicationService.toggleRecruitApplicationLike(recruitApplicationId, authenticatedMember.getMemberId());
         return EnvelopeResponse.<Void>builder()
+                .build();
+    }
+
+    @GetMapping("/recruit-applications/{recruitApplicationId}")
+    public EnvelopeResponse<RecruitApplicationElement> getRecruitApplicationByIdAndRegisterId(@PathVariable Long recruitApplicationId, AuthenticatedMember authenticatedMember) {
+        return EnvelopeResponse.<RecruitApplicationElement>builder()
+                .data(recruitApplicationService.getRecruitApplicationByIdAndRegisterId(recruitApplicationId, 1L))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/domain/RecruitApplication.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/domain/RecruitApplication.java
@@ -37,7 +37,15 @@ public class RecruitApplication {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column
+    @Builder.Default
+    private Boolean isLike = Boolean.FALSE;
+
     public void changeStatus(MatchStatus matchStatus) {
         this.matchStatus = matchStatus;
+    }
+
+    public void toggleLike() {
+        this.isLike = !this.isLike;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitApplicationsResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitApplicationsResDto.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafsound.domain.recruitapplication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetRecruitApplicationsResDto {
+
+    private List<RecruitApplicationElement> recruitApplications;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitApplicationsResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitApplicationsResDto.java
@@ -13,5 +13,12 @@ public class GetRecruitApplicationsResDto {
 
     public GetRecruitApplicationsResDto(List<RecruitApplicationElement> recruitApplications) {
         this.recruitApplications = recruitApplications;
+
+        recruitApplications.sort((r1, r2)->{
+            if(r1.getIsLike().equals(r2.getIsLike())) {
+                return r1.getRecruitApplicationId().compareTo(r2.getRecruitApplicationId());
+            }
+            return Boolean.compare(r2.getIsLike(), r1.getIsLike());
+        });
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitApplicationsResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitApplicationsResDto.java
@@ -1,6 +1,5 @@
 package com.ssafy.ssafsound.domain.recruitapplication.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,8 +7,11 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class GetRecruitApplicationsResDto {
 
     private List<RecruitApplicationElement> recruitApplications;
+
+    public GetRecruitApplicationsResDto(List<RecruitApplicationElement> recruitApplications) {
+        this.recruitApplications = recruitApplications;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
@@ -33,11 +33,14 @@ public class RecruitApplicationElement {
     @JsonProperty
     private String question;
 
+    @JsonProperty
+    private Boolean isLike;
+
     public RecruitApplicationElement(Long recruitApplicationId, MatchStatus matchStatus, MetaData type,
                                      Long memberId, String nickName,
                                      Integer semester, Boolean major, MetaData campus,
                                      AuthenticationStatus certificationState, String majorType,
-                                     String reply, String question) {
+                                     String reply, String question, Boolean isLike) {
 
         this.recruitApplicationId = recruitApplicationId;
         this.matchStatus = matchStatus;
@@ -53,5 +56,6 @@ public class RecruitApplicationElement {
                 .build();
         this.reply = reply;
         this.question = question;
+        this.isLike = isLike;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
@@ -1,0 +1,55 @@
+package com.ssafy.ssafsound.domain.recruitapplication.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.ssafsound.domain.member.domain.AuthenticationStatus;
+import com.ssafy.ssafsound.domain.member.dto.SSAFYInfo;
+import com.ssafy.ssafsound.domain.meta.domain.MetaData;
+import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
+
+public class RecruitApplicationElement {
+    @JsonProperty
+    private Long recruitApplicationId;
+
+    @JsonProperty
+    private MatchStatus matchStatus;
+
+    @JsonProperty
+    private MetaData type;
+
+    @JsonProperty
+    private Long memberId;
+
+    @JsonProperty
+    private String nickName;
+
+    @JsonProperty
+    private SSAFYInfo ssafyInfo;
+
+    @JsonProperty
+    private String reply;
+
+    @JsonProperty
+    private String question;
+
+    public RecruitApplicationElement(Long recruitApplicationId, MatchStatus matchStatus, MetaData type,
+                                     Long memberId, String nickName,
+                                     Integer semester, Boolean major, MetaData campus,
+                                     AuthenticationStatus certificationState, String majorType,
+                                     String reply, String question) {
+
+        this.recruitApplicationId = recruitApplicationId;
+        this.matchStatus = matchStatus;
+        this.type = type;
+        this.memberId = memberId;
+        this.nickName = nickName;
+        this.ssafyInfo = SSAFYInfo.builder()
+                .semester(semester)
+                .isMajor(major)
+                .campus(campus == null ? null : campus.getName())
+                .certificationState(certificationState == null ? null : certificationState.name())
+                .majorType(majorType)
+                .build();
+        this.reply = reply;
+        this.question = question;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
@@ -5,7 +5,9 @@ import com.ssafy.ssafsound.domain.member.domain.AuthenticationStatus;
 import com.ssafy.ssafsound.domain.member.dto.SSAFYInfo;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
+import lombok.Getter;
 
+@Getter
 public class RecruitApplicationElement {
     @JsonProperty
     private Long recruitApplicationId;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
@@ -13,6 +13,9 @@ public class RecruitApplicationElement {
     private Long recruitApplicationId;
 
     @JsonProperty
+    private String recruitType;
+
+    @JsonProperty
     private MatchStatus matchStatus;
 
     @JsonProperty
@@ -36,13 +39,14 @@ public class RecruitApplicationElement {
     @JsonProperty
     private Boolean isLike;
 
-    public RecruitApplicationElement(Long recruitApplicationId, MatchStatus matchStatus, MetaData type,
+    public RecruitApplicationElement(Long recruitApplicationId, MetaData recruitType, MatchStatus matchStatus, MetaData type,
                                      Long memberId, String nickName,
                                      Integer semester, Boolean major, MetaData campus,
                                      AuthenticationStatus certificationState, String majorType,
                                      String reply, String question, Boolean isLike) {
 
         this.recruitApplicationId = recruitApplicationId;
+        this.recruitType = recruitType.getName();
         this.matchStatus = matchStatus;
         this.type = type;
         this.memberId = memberId;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -23,11 +23,11 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
     @Query("SELECT r FROM recruit_application r left join fetch r.member as m left join fetch m.majorType where r.recruit.id = :recruitId and r.matchStatus = :matchStatus")
     List<RecruitApplication> findByRecruitIdAndMatchStatusFetchMember(Long recruitId, MatchStatus matchStatus);
 
-    @Query("SELECT new com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement(r.id, r.matchStatus, r.type, m.id, m.nickname, m.semester, m.major, m.campus, m.certificationState, mj.name, rp.content, rq.content) from recruit_application r  " +
+    @Query("SELECT new com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement(r.id, r.matchStatus, r.type, m.id, m.nickname, m.semester, m.major, m.campus, m.certificationState, mj.name, rp.content, rq.content, r.isLike) from recruit_application r  " +
             "inner join r.member as m " +
             "inner join m.majorType as mj " +
             "left outer join recruit_question_reply as rp on r.id = rp.application.id " +
-            "inner join rp.question as rq " +
-            "where r.id = :recruitId and r.recruit.member.id = :registerId and r.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.WAITING_REGISTER_APPROVE")
+            "left outer join rp.question as rq " +
+            "where r.recruit.id = :recruitId and r.recruit.member.id = :registerId and r.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.WAITING_REGISTER_APPROVE")
     List<RecruitApplicationElement> findByRecruitIdAndRegisterMemberIdWithQuestionReply(Long recruitId, Long registerId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -23,7 +23,7 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
     @Query("SELECT r FROM recruit_application r left join fetch r.member as m left join fetch m.majorType where r.recruit.id = :recruitId and r.matchStatus = :matchStatus")
     List<RecruitApplication> findByRecruitIdAndMatchStatusFetchMember(Long recruitId, MatchStatus matchStatus);
 
-    @Query("SELECT new com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement(r.id, r.matchStatus, r.type, m.id, m.nickname, m.semester, m.major, m.campus, m.certificationState, mj.name, rp.content, rq.content, r.isLike) from recruit_application r  " +
+    @Query("SELECT new com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement(r.id, r.type, r.matchStatus, r.type, m.id, m.nickname, m.semester, m.major, m.campus, m.certificationState, mj.name, rp.content, rq.content, r.isLike) from recruit_application r  " +
             "inner join r.member as m " +
             "inner join m.majorType as mj " +
             "left outer join recruit_question_reply as rp on r.id = rp.application.id " +

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafsound.domain.recruitapplication.repository;
 
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -21,4 +22,12 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
 
     @Query("SELECT r FROM recruit_application r left join fetch r.member as m left join fetch m.majorType where r.recruit.id = :recruitId and r.matchStatus = :matchStatus")
     List<RecruitApplication> findByRecruitIdAndMatchStatusFetchMember(Long recruitId, MatchStatus matchStatus);
+
+    @Query("SELECT new com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement(r.id, r.matchStatus, r.type, m.id, m.nickname, m.semester, m.major, m.campus, m.certificationState, mj.name, rp.content, rq.content) from recruit_application r  " +
+            "inner join r.member as m " +
+            "inner join m.majorType as mj " +
+            "left outer join recruit_question_reply as rp on r.id = rp.application.id " +
+            "inner join rp.question as rq " +
+            "where r.id = :recruitId and r.recruit.member.id = :registerId and r.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.WAITING_REGISTER_APPROVE")
+    List<RecruitApplicationElement> findByRecruitIdAndRegisterMemberIdWithQuestionReply(Long recruitId, Long registerId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -30,4 +30,12 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
             "left outer join rp.question as rq " +
             "where r.recruit.id = :recruitId and r.recruit.member.id = :registerId and r.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.WAITING_REGISTER_APPROVE")
     List<RecruitApplicationElement> findByRecruitIdAndRegisterMemberIdWithQuestionReply(Long recruitId, Long registerId);
+
+    @Query("SELECT new com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement(r.id, r.type, r.matchStatus, r.type, m.id, m.nickname, m.semester, m.major, m.campus, m.certificationState, mj.name, rp.content, rq.content, r.isLike) from recruit_application r  " +
+            "inner join r.member as m " +
+            "inner join m.majorType as mj " +
+            "left outer join recruit_question_reply as rp on r.id = rp.application.id " +
+            "left outer join rp.question as rq " +
+            "where r.id = :recruitApplicationId and r.recruit.member.id = :registerId and r.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.WAITING_REGISTER_APPROVE")
+    RecruitApplicationElement findByRecruitApplicationIdAndRegisterId(Long recruitApplicationId, Long registerId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -17,6 +17,7 @@ import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitApplicationsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitParticipantsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.PostRecruitApplicationReqDto;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
 import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicationRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.validator.RecruitApplicationValidator;
 import com.ssafy.ssafsound.global.common.exception.GlobalErrorInfo;
@@ -125,6 +126,11 @@ public class RecruitApplicationService {
 
         if(!recruitApplication.getRecruit().getMember().getId().equals(memberId)) throw new RecruitException(RecruitErrorInfo.INVALID_CHANGE_MEMBER_OPERATION);
         recruitApplication.toggleLike();
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitApplicationElement getRecruitApplicationByIdAndRegisterId(Long recruitApplicationId, Long registerId) {
+        return recruitApplicationRepository.findByRecruitApplicationIdAndRegisterId(recruitApplicationId, registerId);
     }
 
     private void changeRecruitApplicationState(RecruitApplication recruitApplication, Long memberId,

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -14,6 +14,7 @@ import com.ssafy.ssafsound.domain.recruit.repository.RecruitQuestionReplyReposit
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitApplicationsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitParticipantsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.PostRecruitApplicationReqDto;
 import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicationRepository;
@@ -110,6 +111,11 @@ public class RecruitApplicationService {
                 .findByRecruitIdAndMatchStatusFetchMember(recruitId, MatchStatus.DONE);
 
         return GetRecruitParticipantsResDto.from(recruitApplications);
+    }
+
+    @Transactional(readOnly = true)
+    public GetRecruitApplicationsResDto getRecruitApplications(Long recruitId, Long memberId) {
+        return new GetRecruitApplicationsResDto(recruitApplicationRepository.findByRecruitIdAndRegisterMemberIdWithQuestionReply(recruitId, memberId));
     }
 
     private void changeRecruitApplicationState(RecruitApplication recruitApplication, Long memberId,

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -118,6 +118,15 @@ public class RecruitApplicationService {
         return new GetRecruitApplicationsResDto(recruitApplicationRepository.findByRecruitIdAndRegisterMemberIdWithQuestionReply(recruitId, memberId));
     }
 
+    @Transactional
+    public void toggleRecruitApplicationLike(Long recruitApplicationId, Long memberId) {
+        RecruitApplication recruitApplication = recruitApplicationRepository.findByIdFetchRecruitWriter(recruitApplicationId)
+                .orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
+
+        if(!recruitApplication.getRecruit().getMember().getId().equals(memberId)) throw new RecruitException(RecruitErrorInfo.INVALID_CHANGE_MEMBER_OPERATION);
+        recruitApplication.toggleLike();
+    }
+
     private void changeRecruitApplicationState(RecruitApplication recruitApplication, Long memberId,
                                                MatchStatus status, RecruitApplicationValidator validator) {
         if(validator.hasError(recruitApplication, memberId)) {

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -87,6 +87,7 @@ class RecruitApplicationServiceTest {
 
     RecruitApplication recruitApplication = RecruitApplication.builder()
             .id(1L)
+            .isLike(false)
             .matchStatus(MatchStatus.WAITING_REGISTER_APPROVE)
             .recruit(recruit)
             .type(new MetaData(RecruitType.DESIGN))
@@ -295,5 +296,22 @@ class RecruitApplicationServiceTest {
         assertDoesNotThrow(()->{
             recruitApplicationService.getRecruitParticipants(1L);
         });
+    }
+
+    @DisplayName("등록자 리크루트 참여 좋아요 토글")
+    @Test
+    void Given_RecruitApplicationIdAndRegisterId_When_GetRecruitApplicationLikeThen_Success() {
+        assertAll(
+                ()-> assertDoesNotThrow(()-> recruitApplicationService.toggleRecruitApplicationLike(1L, 1L)),
+                ()->assertEquals(true, recruitApplication.getIsLike())
+        );
+    }
+
+    @DisplayName("비정상 사용자 등록자 리크루트 참여 좋아요 토글 요청")
+    @Test
+    void Given_RecruitApplicationIdAndNotValidMemberId_When_GetRecruitApplicationLikeThen_Fail() {
+        assertThrows(RecruitException.class,
+                ()-> recruitApplicationService.toggleRecruitApplicationLike(1L, 2L)
+        );
     }
 }


### PR DESCRIPTION
## Issues

- #38 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

### [11. 등록자 리크루팅 신청 목록 조회 기능]
등록자는 자신이 작성한 리크루팅에 참여 신청한 사용자 목록을 조회할 수 있다.

### [12. 등록자 리크루팅 신청 단건 조회 기능]
등록자는 신청된 목록을 눌러 사용자의 답변을 조회할 수 있다.
조회 여부에 따라 오픈 프로필 -> 프로젝트탭 -> 등록한 프로젝트에서 표시되는 읽지않음 상태가 결정된다.

### [13. 등록자 리크루팅 신청 목록 좋아요 기능]
등록자는 참여 신청된 사용자 목록을 확인하고, 관심이 가는 유저의 신청에 좋아요를 눌러 다음 조회 시 상단부에 위치할 수 있도록 순서를 조절할 수 있다. (토글)

---

RecruitQuestion, RecruitQuestionReply가 차후 복수개로 늘어날 수 있음을 고려한 설계로 인해,
연관관계를 이용한 쿼리가 어렵습니다. 또한 일반적인 메서드 쿼리로는 N+1문제를 해결할 수 없기에 JPQL로 직접 쿼리를 작성했습니다.
해당 부분을 중점적으로 리뷰해주시고, 논리적 오류가 없는지 같이 봐주세요.
차후 엔티티 설계 자체를 단건으로 다시 바꾸던가, QueryDSL 등 도입을 검토해야할 것 같습니다. 
