### PR TITLE
feat: 등록자 리크루트 수정 삭제 

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafsound.domain.recruit.controller;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
 import com.ssafy.ssafsound.domain.recruit.dto.GetRecruitDetailResDto;
+import com.ssafy.ssafsound.domain.recruit.dto.PatchRecruitReqDto;
 import com.ssafy.ssafsound.domain.recruit.dto.PostRecruitReqDto;
 import com.ssafy.ssafsound.domain.recruit.service.RecruitService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
@@ -34,5 +35,17 @@ public class RecruitController {
         return EnvelopeResponse.<GetRecruitDetailResDto>builder()
                 .data(recruitService.getRecruitDetail(recruitId))
                 .build();
+    }
+
+    @PatchMapping("/{recruitId}")
+    public EnvelopeResponse<Void> updateRecruit(@PathVariable Long recruitId, AuthenticatedMember memberInfo, @RequestBody PatchRecruitReqDto patchRecruitReqDto) {
+        recruitService.updateRecruit(recruitId, memberInfo.getMemberId(), patchRecruitReqDto);
+        return EnvelopeResponse.<Void>builder().build();
+    }
+
+    @DeleteMapping("/{recruitId}")
+    public EnvelopeResponse<Void> deleteRecruit(@PathVariable Long recruitId, AuthenticatedMember memberInfo) {
+        recruitService.deleteRecruit(recruitId, memberInfo.getMemberId());
+        return EnvelopeResponse.<Void>builder().build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/Recruit.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/Recruit.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafsound.domain.recruit.domain;
 
 import com.ssafy.ssafsound.domain.BaseTimeEntity;
 import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.recruit.dto.PatchRecruitReqDto;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitErrorInfo;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitException;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -98,6 +100,12 @@ public class Recruit extends BaseTimeEntity {
                 recruitLimitation.getCurrentNumber() < recruitLimitation.getLimitation()
         ).count();
         return isExpirationDate || (notFullRecruitTypeCnt == 0);
+    }
+
+    public void update(PatchRecruitReqDto patchRecruitReqDto) {
+        this.endDateTime = patchRecruitReqDto.getRecruitEnd().atTime(LocalTime.MAX);
+        this.title = patchRecruitReqDto.getTitle();
+        this.content = patchRecruitReqDto.getContent();
     }
 
     public void increaseView() {

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PatchRecruitReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PatchRecruitReqDto.java
@@ -1,0 +1,39 @@
+package com.ssafy.ssafsound.domain.recruit.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ssafy.ssafsound.domain.recruit.validator.CheckRecruitLimitElement;
+import com.ssafy.ssafsound.domain.meta.validator.CheckSkills;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.NotEmpty;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatchRecruitReqDto {
+
+    @NotEmpty
+    private String category;
+
+    @FutureOrPresent
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate recruitEnd;
+
+    @NotEmpty
+    private String title;
+
+    @NotEmpty
+    private String content;
+
+    @CheckSkills
+    private List<String> skills;
+
+    @CheckRecruitLimitElement
+    private List<RecruitLimitElement> limitations = new ArrayList<>();
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PostRecruitReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PostRecruitReqDto.java
@@ -49,7 +49,7 @@ public class PostRecruitReqDto {
     @CheckRecruitLimitElement
     private List<RecruitLimitElement> limitations = new ArrayList<>();
 
-    public Recruit createRecruitFromPredefinedMetadata(MetaDataConsumer consumer) {
+    public Recruit to() {
         Recruit recruit = Recruit.builder()
                 .view(0L)
                 .category(Category.valueOf(category))
@@ -61,20 +61,7 @@ public class PostRecruitReqDto {
                 .build();
 
         setRecruitQuestions(recruit);
-        setRecruitSkillFromPredefinedMetaData(consumer, recruit);
         return recruit;
-    }
-
-    private void setRecruitSkillFromPredefinedMetaData(MetaDataConsumer consumer, Recruit recruit) {
-        if(skills == null) return;
-
-        List<RecruitSkill> recruitSkills = skills.stream().map((skill)->(
-                RecruitSkill.builder()
-                        .recruit(recruit)
-                        .skill(consumer.getMetaData(MetaDataType.SKILL.name(), skill)))
-                        .build()
-        ).collect(Collectors.toList());
-        recruit.setRecruitSkill(recruitSkills);
     }
 
     private void setRecruitQuestions (Recruit recruit) {

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
@@ -12,7 +12,8 @@ public enum RecruitErrorInfo {
     NOT_RECRUITING_TYPE("905", "해당 스터디/프로젝트에서 모집하지 않는 역할군입니다."),
     NOT_SAME_LENGTH_RECRUIT_QUESTION_ANSWER("906", "질문에 대한 모든 답변이 필요합니다."),
     IS_ALREADY_FULL("907", "이미 모집 인원이 가득찬 스터디/프로젝트 입니다."),
-    IS_DELETED("908", "이미 삭제돤 스터디/프로젝트입니다.");
+    IS_DELETED("908", "이미 삭제돤 스터디/프로젝트입니다."),
+    NOT_BELOW_PREV_LIMITATIONS("909", "스터디/프로젝트 인원은 감소할 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
@@ -12,7 +12,7 @@ public enum RecruitErrorInfo {
     NOT_RECRUITING_TYPE("905", "해당 스터디/프로젝트에서 모집하지 않는 역할군입니다."),
     NOT_SAME_LENGTH_RECRUIT_QUESTION_ANSWER("906", "질문에 대한 모든 답변이 필요합니다."),
     IS_ALREADY_FULL("907", "이미 모집 인원이 가득찬 스터디/프로젝트 입니다."),
-    IS_DELETED("908", "이미 삭제돤 스터디/프로젝트입니다."),
+    IS_DELETED("908", "이미 삭제된 스터디/프로젝트입니다."),
     NOT_BELOW_PREV_LIMITATIONS("909", "스터디/프로젝트 인원은 감소할 수 없습니다.");
 
     private final String code;

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/dto/PostRecruitReqDtoTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/dto/PostRecruitReqDtoTest.java
@@ -46,11 +46,9 @@ class PostRecruitReqDtoTest {
             Mockito.lenient().when(metaDataConsumer.getMetaData(MetaDataType.SKILL.name(), skill.getName())).thenReturn(new MetaData(skill));
         });
 
-        Recruit convertResult = dto.createRecruitFromPredefinedMetadata(metaDataConsumer);
+        Recruit convertResult = dto.to();
         List<String> questions = convertResult.getQuestions().stream()
                 .map(RecruitQuestion::getContent).collect(Collectors.toList());
-        List<String> skills = convertResult.getSkills()
-                .stream().map(skill->skill.getSkill().getName()).collect(Collectors.toList());
 
         assertAll(
                 ()->assertEquals(Category.STUDY, convertResult.getCategory()),
@@ -63,19 +61,6 @@ class PostRecruitReqDtoTest {
                         if (questions.size() != 0) {
                             for (int i = 0; i < questions.size(); ++i) {
                                 assertEquals(freeQuestion.get(i), questions.get(i));
-                            }
-                        }
-                    }
-                },
-
-                ()->{
-                    if(necessarySkills == null) {
-                        assertEquals(0, skills.size());
-                    } else {
-                        assertEquals(necessarySkills.size(), skills.size());
-                        if (skills.size() != 0) {
-                            for (int i = 0; i < skills.size(); ++i) {
-                                assertEquals(necessarySkills.get(i), skills.get(i));
                             }
                         }
                     }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
@@ -125,6 +125,10 @@ class RecruitServiceTest {
         Arrays.stream(RecruitType.values()).forEach(recruitType -> Mockito.lenient()
                 .when(metaDataConsumer.getMetaData(MetaDataType.RECRUIT_TYPE.name(), recruitType.getName()))
                 .thenReturn(new MetaData(recruitType)));
+
+        Arrays.stream(Skill.values()).forEach(skill -> Mockito.lenient()
+                .when(metaDataConsumer.getMetaData(MetaDataType.SKILL.name(), skill.getName()))
+                .thenReturn(new MetaData(skill)));
     }
 
     @DisplayName("토큰과 정상 리크루트글 등록 요청이 넘어온 경우 리크루트 글 등록 성공")
@@ -157,6 +161,14 @@ class RecruitServiceTest {
                         } else {
                             assertEquals(0, recruitLimitation.getCurrentNumber());
                         }
+                    }
+                },
+                ()-> {
+                    List<RecruitSkill> skills = recruit.getSkills();
+                    Skill[] allSkill = Skill.values();
+                    int len = skills.size();
+                    for(int i=0; i<len; ++i) {
+                        assertEquals(allSkill[i].getName(), skills.get(i).getSkill().getName());
                     }
                 }
         );


### PR DESCRIPTION
## Issues

- #40 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 리크루트 수정 기능 추가
- 리크루트 삭제 기능 추가


## 기타
1. 리크루트 삭제의 경우 리크루트 자체는 soft delete, 연관된 데이터는 별도의 변경 없이 데이터를 유지합니다. 
2. 리크루트 수정의 경우 기존에 정한 인원 수 아래로 내릴 수 없으며, 기존에 모집했던 모집군을 삭제할 수 없습니다. 
3. 리크루트 등록 페이지에서 지원파트 선택 여부가 수정 가능해야된다면 회의 이후 코드가 일부 수정될 수 있습니다.