### PR TITLE
fix: 점심 메뉴 api 업데이트

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
@@ -1,8 +1,10 @@
 package com.ssafy.ssafsound.domain.auth.validator;
 
+import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
 import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -24,6 +26,9 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         String token = AuthorizationExtractor.extractToken("accessToken", request);
+        if (token == null && request.getMethod().equals("GET")) {
+            return AuthenticatedMember.builder().build();
+        }
 
         return jwtTokenProvider.getParsedClaims(token);
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
@@ -11,14 +11,14 @@ import javax.servlet.http.HttpServletRequest;
 @NoArgsConstructor
 public class AuthorizationExtractor {
 
-    public static String extractToken(String tokeType, HttpServletRequest request) {
+    public static String extractToken(String tokenType, HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
 
         // cookie 없는 경우(미인증)
         if (cookies == null) return null;
 
         for (Cookie cookie : cookies) {
-            if (cookie.getName().equals(tokeType)) {
+            if (cookie.getName().equals(tokenType)) {
                 return cookie.getValue();
             }
         }

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthorizationExtractor.java
@@ -13,11 +13,16 @@ public class AuthorizationExtractor {
 
     public static String extractToken(String tokeType, HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
+
+        // cookie 없는 경우(미인증)
+        if (cookies == null) return null;
+
         for (Cookie cookie : cookies) {
             if (cookie.getName().equals(tokeType)) {
                 return cookie.getValue();
             }
         }
-        throw new AuthException(AuthErrorInfo.AUTH_TOKEN_INVALID);
+
+        return null;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/controller/LunchController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/controller/LunchController.java
@@ -43,4 +43,13 @@ public class LunchController {
                 .data(lunchService.saveLunchPoll(user.getMemberId(), lunchId))
                 .build();
     }
+
+    @PostMapping("/poll/revert/{lunchId}")
+    public EnvelopeResponse<PostLunchPollResDto> revertLunchPoll(AuthenticatedMember user, @PathVariable @NumberFormat Long lunchId){
+
+        return EnvelopeResponse.<PostLunchPollResDto>builder()
+                .data(lunchService.deleteLunchPoll(user.getMemberId(), lunchId))
+                .build();
+    }
+
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/controller/LunchController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/controller/LunchController.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.lunch.controller;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import com.ssafy.ssafsound.domain.auth.validator.Authentication;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListReqDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchResDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListResDto;
@@ -29,15 +30,15 @@ public class LunchController {
     }
 
     @GetMapping
-    public EnvelopeResponse<GetLunchListResDto> getLunchesByCampusAndDate(@Valid GetLunchListReqDto getLunchListReqDto){
+    public EnvelopeResponse<GetLunchListResDto> getLunchesByCampusAndDate(@Authentication AuthenticatedMember member, @Valid GetLunchListReqDto getLunchListReqDto){
 
         return EnvelopeResponse.<GetLunchListResDto>builder()
-                .data(lunchService.findLunches(getLunchListReqDto))
+                .data(lunchService.findLunches(member.getMemberId(), getLunchListReqDto))
                 .build();
     }
 
     @PostMapping("/poll/{lunchId}")
-    public EnvelopeResponse<PostLunchPollResDto> postLunchPoll(AuthenticatedMember user, @PathVariable @NumberFormat Long lunchId){
+    public EnvelopeResponse<PostLunchPollResDto> postLunchPoll(@Authentication AuthenticatedMember user, @PathVariable @NumberFormat Long lunchId){
 
         return EnvelopeResponse.<PostLunchPollResDto>builder()
                 .data(lunchService.saveLunchPoll(user.getMemberId(), lunchId))
@@ -45,7 +46,7 @@ public class LunchController {
     }
 
     @PostMapping("/poll/revert/{lunchId}")
-    public EnvelopeResponse<PostLunchPollResDto> revertLunchPoll(AuthenticatedMember user, @PathVariable @NumberFormat Long lunchId){
+    public EnvelopeResponse<PostLunchPollResDto> revertLunchPoll(@Authentication AuthenticatedMember user, @PathVariable @NumberFormat Long lunchId){
 
         return EnvelopeResponse.<PostLunchPollResDto>builder()
                 .data(lunchService.deleteLunchPoll(user.getMemberId(), lunchId))

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/dto/GetLunchListReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/dto/GetLunchListReqDto.java
@@ -1,7 +1,5 @@
 package com.ssafy.ssafsound.domain.lunch.dto;
 
-import com.ssafy.ssafsound.domain.meta.domain.MetaData;
-import com.ssafy.ssafsound.domain.meta.service.EnumMetaDataConsumer;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/dto/GetLunchListResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/dto/GetLunchListResDto.java
@@ -14,11 +14,15 @@ public class GetLunchListResDto {
     private Long totalPollCount = 0L;
 
     @Builder.Default
+    private Long polledAt = -1L;
+
+    @Builder.Default
     private List<GetLunchListElementResDto> menus = new ArrayList<>();
 
-    public static GetLunchListResDto of(List<GetLunchListElementResDto> menuList){
+    public static GetLunchListResDto of(List<GetLunchListElementResDto> menuList, Long polledAt){
         return GetLunchListResDto.builder()
                 .menus(menuList)
+                .polledAt(polledAt)
                 .totalPollCount(menuList.stream().mapToLong(GetLunchListElementResDto::getPollCount).sum())
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/exception/LunchErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/exception/LunchErrorInfo.java
@@ -5,10 +5,11 @@ import lombok.Getter;
 @Getter
 public enum LunchErrorInfo {
     INVALID_DATE("601","유효하지 않은 날짜입니다."),
-    INVALID_LUNCH_ID("602","유효하지 않은 점심 데이터입니다."),
+    INVALID_LUNCH_ID("602","유효하지 않은 데이터입니다."),
     NO_LUNCH_DATE("603","점심 데이터가 존재하지 않는 날짜입니다."),
-    DUPLICATE_LUNCH_POLL("604","이미 투표한 점심 메뉴입니다."),
-    SCRAPING_ERROR("605","점심 메뉴 스크래핑 도중 에러가 발생했습니다.");
+    DUPLICATE_LUNCH_POLL("604","이미 투표한 메뉴입니다."),
+    NO_LUNCH_POLL("605","투표한 적이 없는 메뉴입니다."),
+    SCRAPING_ERROR("606","메뉴 스크래핑 도중 에러가 발생했습니다.");
 
     private String code;
     private String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/repository/LunchPollRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/repository/LunchPollRepository.java
@@ -1,5 +1,6 @@
 package com.ssafy.ssafsound.domain.lunch.repository;
 
+import com.ssafy.ssafsound.domain.lunch.domain.Lunch;
 import com.ssafy.ssafsound.domain.lunch.domain.LunchPoll;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Repository
 public interface LunchPollRepository extends JpaRepository<LunchPoll, Long> {
@@ -17,4 +19,5 @@ public interface LunchPollRepository extends JpaRepository<LunchPoll, Long> {
     @Query(value = "insert into lunch_poll (lunch_id,member_id,polled_at) values(:lunchId, :memberId, :polledAt)", nativeQuery = true)
     void saveByMember_IdAndLunch_Id(Long memberId, Long lunchId, LocalDate polledAt);
 
+    Optional<LunchPoll> findByMember_IdAndLunch(Long memberId, Lunch lunch);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
@@ -81,8 +81,25 @@ public class LunchService {
         // 4-2. 오늘 첫 투표인 경우
         else lunchPollRepository.saveByMember_IdAndLunch_Id(memberId, lunchId, LocalDate.now());
 
-        return PostLunchPollResDto.builder()
-                .pollCount((long) lunch.getLunchPolls().size())
-                .build();
+        return PostLunchPollResDto.of((long) lunch.getLunchPolls().size());
     }
+
+    @Transactional
+    public PostLunchPollResDto deleteLunchPoll(Long memberId, Long lunchId) {
+
+        // Lunch 엔티티 조회 후 validate
+        Lunch lunch = lunchRepository.findById(lunchId)
+                .orElseThrow(() -> new LunchException((LunchErrorInfo.INVALID_LUNCH_ID)));
+
+        // 멤버 id와 Lunch 엔티티 기반으로 LunchPoll 엔티티 조회 후 validate
+        LunchPoll lunchPoll = lunchPollRepository.findByMember_IdAndLunch(memberId, lunch)
+                .orElseThrow(() -> new LunchException(LunchErrorInfo.NO_LUNCH_POLL));
+
+        // 투표 삭제
+        lunchPollRepository.delete(lunchPoll);
+
+        // 변화한 투표 수 리턴
+        return PostLunchPollResDto.of((long) lunch.getLunchPolls().size());
+    }
+
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,10 +7,31 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:h2:mem:db;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
+    url: "jdbc:h2:mem:db;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"
+    driver-class-name: "org.h2.Driver"
     username: sa
 
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always
+
+  constant:
+    semester:
+      MIN_SEMESTER: 1
+      MAX_SEMESTER: 10
+    post:
+      HOT_POST_LIKES_THRESHOLD: 10
+
+    global:
+      validator:
+        IMAGE_EXTENSIONS: jpg, jpeg, png, bmp, webp
+
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
 
   jpa:
     hibernate:
@@ -28,7 +49,7 @@ spring:
 
   config:
     import:
-        - application-oauth.yml
-        - application-cloud.yml
-        - application-security.yml
-        - application-scraper.yml
+      - application-oauth.yml
+      - application-cloud.yml
+      - application-security.yml
+      - application-scraper.yml


### PR DESCRIPTION
## Issues

- #66

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- @Authenicate 어노테이션의 extractor 로직이 변경되었습니다. 다음은 변경된 AuthorizationExtractor 클래스의 extractToken 메소드입니다.
```java
    public static String extractToken(String tokeType, HttpServletRequest request) {
        Cookie[] cookies = request.getCookies();

        // cookie 없는 경우(미인증)
        if (cookies == null) return null;

        for (Cookie cookie : cookies) {
            if (cookie.getName().equals(tokeType)) {
                return cookie.getValue();
            }
        }

        return null;
    }
```
위 코드는 기존에는 cookies가 아예 없는 경우는 NullPointerException이 발생하며, 토큰을 getName으로 뽑을 수 없는 경우에는AuthException을 던지고 있었습니다.
그러나 그냥 null 값을 AuthenicationArgumentResolver에 반환해주도록 변경했습니다.

다음은 AuthenicationArgumentResolver에서 extractToken 호출하던 메소드입니다.

기존에는 if 문이 없었지만 If문을 추가하여 미인증 GET 요청의 경우 컨트롤러에 초기화되지 않은 AuthenticatedMember를 넣어줄 수 있도록 합니다.
```java
    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
        String token = AuthorizationExtractor.extractToken("accessToken", request);
        if (token == null && request.getMethod().equals("GET")) {
            return AuthenticatedMember.builder().build();
        }

        return jwtTokenProvider.getParsedClaims(token);
    }
```
자연스럽게 인증이 필요한 POST와 같은 컨트롤러 메소드에서는 `return jwtTokenProvider.getParsedClaims(token)`을 통해서 토큰에 문제가 있다면 AuthException 던져지도록 유지하였습니다.

- 이미 투표한 점심 메뉴 투표를 삭제하는 api를 추가하였습니다.
- 기존의 점심 투표 메뉴 목록 조회 api에서 인증된 유저가 투표한 인덱스 정보도 함께 응답하도록 api를 변경했습니다.
