### PR TITLE
refactor: 리크루트 데이터 베이스 컬럼 추가 사항 반영

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
@@ -20,7 +20,7 @@ public class RecruitController {
 
     @PostMapping
     public EnvelopeResponse<Void> saveRecruit(AuthenticatedMember memberInfo, @Valid @RequestBody PostRecruitReqDto recruitReqDto) {
-        recruitService.saveRecruit(memberInfo, recruitReqDto);
+        recruitService.saveRecruit(memberInfo.getMemberId(), recruitReqDto);
         return EnvelopeResponse.<Void>builder().build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/Recruit.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/Recruit.java
@@ -98,10 +98,6 @@ public class Recruit extends BaseTimeEntity {
         this.limitations = limitations;
     }
 
-    public void addApplications(RecruitApplication application) {
-        this.applications.add(application);
-    }
-
     public boolean isFinishedRecruit() {
         boolean isExpirationDate = LocalDateTime.now().isAfter(this.getEndDateTime());
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/Recruit.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/Recruit.java
@@ -2,6 +2,8 @@ package com.ssafy.ssafsound.domain.recruit.domain;
 
 import com.ssafy.ssafsound.domain.BaseTimeEntity;
 import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.meta.converter.RecruitTypeConverter;
+import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.recruit.dto.PatchRecruitReqDto;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitErrorInfo;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitException;
@@ -50,6 +52,9 @@ public class Recruit extends BaseTimeEntity {
     @Column
     private Boolean deletedRecruit;
 
+    @Convert(converter = RecruitTypeConverter.class)
+    private MetaData registerRecruitType;
+
     @OneToMany(mappedBy = "recruit", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @Builder.Default
     private List<RecruitSkill> skills = new ArrayList<>();
@@ -75,6 +80,10 @@ public class Recruit extends BaseTimeEntity {
             throw new RecruitException(RecruitErrorInfo.INVALID_CHANGE_MEMBER_OPERATION);
         }
         this.member = member;
+    }
+
+    public void setRegisterRecruitType(MetaData registerRecruitType) {
+        this.registerRecruitType = registerRecruitType;
     }
 
     public void setRecruitQuestions(List<RecruitQuestion> questions) {

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitDetailResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitDetailResDto.java
@@ -39,9 +39,14 @@ public class GetRecruitDetailResDto {
         List<RecruitSkillElement> skills = recruit.getSkills().stream()
                 .map(RecruitSkillElement::from)
                 .collect(Collectors.toList());
+
         List<RecruitLimitElement> limits = recruit.getLimitations().stream()
                 .map(RecruitLimitElement::from)
                 .collect(Collectors.toList());
+
+        String registerRecruitType = recruit.getRegisterRecruitType().getName();
+        // 등록자의 모집 타입도 조회 api에서는 인원에 포함되어야한다.
+        addRegisterRecruitType(limits, registerRecruitType);
 
         return GetRecruitDetailResDto.builder()
                 .recruitId(recruit.getId())
@@ -59,5 +64,17 @@ public class GetRecruitDetailResDto {
                 .limits(limits)
                 .view(recruit.getView())
                 .build();
+    }
+
+    private static void addRegisterRecruitType(List<RecruitLimitElement> limits, String registerRecruitType) {
+        for(RecruitLimitElement limit: limits) {
+            if(limit.getRecruitType().equals(registerRecruitType)) {
+                limit.addRegisterLimit();
+                return;
+            }
+        }
+
+        // 리크루트 등록 시 모집 인원 제한에 등록자가 포함되지 않는 경우 인원 제한 타입을 추가한다.
+        limits.add(new RecruitLimitElement(registerRecruitType, 1));
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PatchRecruitReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PatchRecruitReqDto.java
@@ -3,6 +3,7 @@ package com.ssafy.ssafsound.domain.recruit.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ssafy.ssafsound.domain.recruit.validator.CheckRecruitLimitElement;
 import com.ssafy.ssafsound.domain.meta.validator.CheckSkills;
+import com.ssafy.ssafsound.domain.recruit.validator.CheckRecruitType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,9 @@ public class PatchRecruitReqDto {
 
     @NotEmpty
     private String category;
+
+    @CheckRecruitType
+    private String registerRecruitType;
 
     @FutureOrPresent
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/RecruitLimitElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/RecruitLimitElement.java
@@ -12,6 +12,10 @@ public class RecruitLimitElement {
     private String recruitType;
     private int limit;
 
+    public void addRegisterLimit() {
+        limit++;
+    }
+
     public static RecruitLimitElement from(RecruitLimitation recruitLimitation) {
         return new RecruitLimitElement(recruitLimitation.getType().getName(), recruitLimitation.getLimitation());
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitRepository.java
@@ -14,4 +14,7 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long> {
 
     @Query("SELECT r FROM recruit r left join fetch r.member left join fetch r.limitations where r.id = :recruitId")
     Optional<Recruit> findByIdUsingFetchJoinRegisterAndRecruitLimitation(Long recruitId);
+
+    @Query("SELECT r FROM recruit r inner join fetch r.member where r.id = :recruitId")
+    Recruit findByIdFetchJoinRegister(Long recruitId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
@@ -70,7 +70,11 @@ public class RecruitService {
                 .orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
         if(!recruit.getMember().getId().equals(memberId)) throw new RecruitException(RecruitErrorInfo.INVALID_CHANGE_MEMBER_OPERATION);
 
+        // 리크루트 기술 스택 업데이트
         setRecruitSkillFromPredefinedMetaData(metaDataConsumer, recruit, recruitReqDto.getSkills());
+
+        // 등록자 모집군 및 모집 인원 제한 수정 -> 등록자의 모집군은 항상 변경가능하며, 그 외의 인원 제한의 경우 등록시 설정한 인원 제한 아래로 수정할 수 없다.
+        recruit.setRegisterRecruitType(metaDataConsumer.getMetaData(MetaDataType.RECRUIT_TYPE.name(), recruitReqDto.getRegisterRecruitType()));
         updateRecruitLimitations(recruitReqDto, recruit);
         recruit.update(recruitReqDto);
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
@@ -35,9 +35,9 @@ public class RecruitService {
     private final MetaDataConsumer metaDataConsumer;
 
     @Transactional
-    public Recruit saveRecruit(AuthenticatedMember userInfo, PostRecruitReqDto postRecruitReqDto) {
+    public Recruit saveRecruit(Long memberId, PostRecruitReqDto postRecruitReqDto) {
         Recruit recruit = postRecruitReqDto.to();
-        Member register = memberRepository.findById(userInfo.getMemberId()).orElseThrow(RuntimeException::new);
+        Member register = memberRepository.findById(memberId).orElseThrow(RuntimeException::new);
         // 등록자는 자신이 속한 역할군을 1가지 선택할 수 있어야한다.
         recruit.setRegister(register);
         recruit.setRegisterRecruitType(metaDataConsumer.getMetaData(MetaDataType.RECRUIT_TYPE.name(), postRecruitReqDto.getRegisterRecruitType()));

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitParticipantsResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitParticipantsResDto.java
@@ -1,5 +1,6 @@
 package com.ssafy.ssafsound.domain.recruitapplication.dto;
 
+import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,5 +17,9 @@ public class GetRecruitParticipantsResDto {
         return new GetRecruitParticipantsResDto(recruitApplications.stream()
                 .map(RecruitParticipantElement::from)
                 .collect(Collectors.toList()));
+    }
+
+    public void addRegisterInfo(Recruit recruit) {
+        this.members.add(RecruitParticipantElement.from(recruit));
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitParticipantElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitParticipantElement.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.recruitapplication.dto;
 
 import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +33,25 @@ public class RecruitParticipantElement {
                 .certificationState(member.getCertificationState().name())
                 .ssafyMember(member.getSsafyMember())
                 .major(member.getMajor())
+                .majorType(majorType)
+                .build();
+    }
+
+    public static RecruitParticipantElement from(Recruit recruit) {
+        Member register = recruit.getMember();
+        String majorType = null;
+        if(register.getMajorType() != null) {
+            majorType = register.getMajorType().getName();
+        }
+
+        return RecruitParticipantElement.builder()
+                .recruitType(recruit.getRegisterRecruitType().getName())
+                .memberId(register.getId())
+                .year(register.getSemester())
+                .nickName(register.getNickname())
+                .certificationState(register.getCertificationState().name())
+                .ssafyMember(register.getSsafyMember())
+                .major(register.getMajor())
                 .majorType(majorType)
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -111,7 +111,9 @@ public class RecruitApplicationService {
         List<RecruitApplication> recruitApplications = recruitApplicationRepository
                 .findByRecruitIdAndMatchStatusFetchMember(recruitId, MatchStatus.DONE);
 
-        return GetRecruitParticipantsResDto.from(recruitApplications);
+        GetRecruitParticipantsResDto getRecruitParticipantsResDto = GetRecruitParticipantsResDto.from(recruitApplications);
+        getRecruitParticipantsResDto.addRegisterInfo(recruitRepository.findByIdFetchJoinRegister(recruitId));
+        return getRecruitParticipantsResDto;
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
@@ -80,6 +80,7 @@ class RecruitServiceTest {
             .id(2L)
             .view(0L)
             .member(member)
+            .registerRecruitType(new MetaData(RecruitType.BACK_END))
             .deletedRecruit(false)
             .startDateTime(LocalDate.now().atStartOfDay())
             .endDateTime(LocalDate.now().plusDays(3).atTime(LocalTime.MAX))
@@ -192,14 +193,35 @@ class RecruitServiceTest {
         assertTrue(recruitService.toggleRecruitScrap(recruitId, memberId));
     }
 
-    @DisplayName("리크루트 상세 조회")
+    @DisplayName("등록자의 리크루트 타입이 인원제한에 포함되지 않은 리크루트 상세 조회")
+    @Test
+    void Given_NotIncludeRegisterRecruitTypeRecruitId_When_GetRecruitDetail_Then_Success() {
+        GetRecruitDetailResDto dto = recruitService.getRecruitDetail(2L);
+        String registerRecruitType = savedRecruit.getRegisterRecruitType().getName();
+
+        assertAll(
+                ()->assertEquals(1L, dto.getView()),
+                ()->assertEquals(false, dto.isFinishedRecruit()),
+                ()-> dto.getLimits().forEach(limit->{
+                    if(limit.getRecruitType().equals(registerRecruitType)) {
+                        assertEquals(1, limit.getLimit());
+                    } else {
+                        assertEquals(2, limit.getLimit());
+                    }
+                })
+        );
+    }
+
+    @DisplayName("등록자의 리크루트 타입이 인원제한에 포함되지 않은 리크루트 상세 조회")
     @Test
     void Given_RecruitId_When_GetRecruitDetail_Then_Success() {
+        savedRecruit.setRegisterRecruitType(new MetaData(RecruitType.DESIGN));
         GetRecruitDetailResDto dto = recruitService.getRecruitDetail(2L);
 
         assertAll(
                 ()->assertEquals(1L, dto.getView()),
-                ()->assertEquals(false, dto.isFinishedRecruit())
+                ()->assertEquals(false, dto.isFinishedRecruit()),
+                ()-> dto.getLimits().forEach(limit-> assertEquals(3, limit.getLimit()))
         );
     }
 

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
@@ -139,7 +139,7 @@ class RecruitServiceTest {
                 .memberId(1L)
                 .build();
 
-        Recruit recruit = recruitService.saveRecruit(existUser, postRecruitReqDto);
+        Recruit recruit = recruitService.saveRecruit(existUser.getMemberId(), postRecruitReqDto);
 
         assertAll(
                 ()-> assertEquals(member, recruit.getMember()),
@@ -175,7 +175,7 @@ class RecruitServiceTest {
                 .memberId(2L)
                 .build();
 
-        assertThrows(RuntimeException.class, ()-> recruitService.saveRecruit(notExistMember, postRecruitReqDto));
+        assertThrows(RuntimeException.class, ()-> recruitService.saveRecruit(notExistMember.getMemberId(), postRecruitReqDto));
     }
 
     @DisplayName("사용자 리크루팅 스크랩 등록")

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
@@ -17,7 +17,6 @@ import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicati
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitLimitationRepository;
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitRepository;
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitScrapRepository;
-import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import com.ssafy.ssafsound.global.common.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -242,7 +241,7 @@ class RecruitServiceTest {
 
         List<String> skills = Arrays.stream(Skill.values()).map(Skill::getName).collect(Collectors.toList());
 
-        PatchRecruitReqDto patchRecruitReqDto = new PatchRecruitReqDto("PROJECT",
+        PatchRecruitReqDto patchRecruitReqDto = new PatchRecruitReqDto("PROJECT", RecruitType.BACK_END.getName(),
                 LocalDate.now(), "제목 수정", "컨텐츠 수정", skills, limits);
 
         recruitService.updateRecruit(2L, 1L, patchRecruitReqDto);
@@ -250,7 +249,8 @@ class RecruitServiceTest {
         assertAll(
                 ()-> assertEquals("제목 수정", savedRecruit.getTitle()),
                 ()-> assertEquals("컨텐츠 수정", savedRecruit.getContent()),
-                ()-> assertEquals(2, savedRecruit.getLimitations().size())
+                ()-> assertEquals(2, savedRecruit.getLimitations().size()),
+                ()-> assertEquals(RecruitType.BACK_END.getName(), savedRecruit.getRegisterRecruitType().getName())
         );
     }
 
@@ -263,7 +263,7 @@ class RecruitServiceTest {
 
         List<String> skills = Arrays.stream(Skill.values()).map(Skill::getName).collect(Collectors.toList());
 
-        PatchRecruitReqDto patchRecruitReqDto = new PatchRecruitReqDto("PROJECT",
+        PatchRecruitReqDto patchRecruitReqDto = new PatchRecruitReqDto("PROJECT", RecruitType.BACK_END.getName(),
                 LocalDate.now(), "제목 수정", "컨텐츠 수정", skills, limits);
 
         assertThrows(RecruitException.class, ()->recruitService.updateRecruit(2L, 1L, patchRecruitReqDto));
@@ -278,7 +278,7 @@ class RecruitServiceTest {
 
         List<String> skills = Arrays.stream(Skill.values()).map(Skill::getName).collect(Collectors.toList());
 
-        PatchRecruitReqDto patchRecruitReqDto = new PatchRecruitReqDto("PROJECT",
+        PatchRecruitReqDto patchRecruitReqDto = new PatchRecruitReqDto("PROJECT", RecruitType.BACK_END.getName(),
                 LocalDate.now(), "제목 수정", "컨텐츠 수정", skills, limits);
 
         assertThrows(RecruitException.class, ()->recruitService.updateRecruit(2L, 1L, patchRecruitReqDto));

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
@@ -144,11 +144,8 @@ class RecruitServiceTest {
         assertAll(
                 ()-> assertEquals(member, recruit.getMember()),
                 ()-> {
-                    RecruitApplication registerApplication = recruit.getApplications().get(0);
-                    assertNotNull(registerApplication);
-                    assertEquals( 1, recruit.getApplications().size());
-                    assertEquals(RecruitType.DESIGN.getName(), registerApplication.getType().getName());
-                    assertEquals(1, registerApplication.getMember().getId());
+                    assertEquals( 0, recruit.getApplications().size());
+                    assertEquals(RecruitType.DESIGN.getName(), recruit.getRegisterRecruitType().getName());
                 },
                 ()-> {
                     List<RecruitLimitation> recruitLimitations = recruit.getLimitations();
@@ -157,11 +154,7 @@ class RecruitServiceTest {
 
                     for(RecruitLimitation recruitLimitation: recruitLimitations) {
                         assertEquals(2, recruitLimitation.getLimitation());
-                        if(recruitLimitation.getType().getName().equals(RecruitType.DESIGN.getName())) {
-                            assertEquals(1, recruitLimitation.getCurrentNumber());
-                        } else {
-                            assertEquals(0, recruitLimitation.getCurrentNumber());
-                        }
+                        assertEquals(0, recruitLimitation.getCurrentNumber());
                     }
                 },
                 ()-> {

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -16,6 +16,7 @@ import com.ssafy.ssafsound.domain.recruit.repository.RecruitQuestionReplyReposit
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitParticipantsResDto;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.PostRecruitApplicationReqDto;
 import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicationRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +76,7 @@ class RecruitApplicationServiceTest {
     Recruit recruit = Recruit.builder()
             .id(1L)
             .member(register)
+            .registerRecruitType(new MetaData(RecruitType.DESIGN))
             .title("스터디/리크루트 모집 제목")
             .content("컨텐츠")
             .build();
@@ -104,17 +106,12 @@ class RecruitApplicationServiceTest {
     List<RecruitApplication> recruitApplications = List.of(
             RecruitApplication.builder()
                     .matchStatus(MatchStatus.DONE)
-                    .member(register)
-                    .type(new MetaData(RecruitType.DESIGN))
-                    .recruit(recruit)
-                    .build(),
-            RecruitApplication.builder()
-                    .matchStatus(MatchStatus.DONE)
                     .member(participant)
                     .type(new MetaData(RecruitType.DESIGN))
                     .recruit(recruit)
                     .build()
     );
+
     @BeforeEach
     void setUpStubAndFixture() {
         // SetUp Fixture
@@ -124,6 +121,8 @@ class RecruitApplicationServiceTest {
         // Repository Mocking
         Mockito.lenient().when(recruitRepository.findByIdUsingFetchJoinRecruitLimitation(1L))
                 .thenReturn(java.util.Optional.ofNullable(recruit));
+        Mockito.lenient().when(recruitRepository.findByIdFetchJoinRegister(1L))
+                .thenReturn(recruit);
         Mockito.lenient().when(recruitApplicationRepository.findByIdAndMemberId(1L, 2L))
                 .thenReturn(java.util.Optional.ofNullable(recruitApplication));
         Mockito.lenient().when(recruitApplicationRepository.findByIdFetchRecruitWriter(1L))
@@ -293,9 +292,11 @@ class RecruitApplicationServiceTest {
     @Test
     void Given_RecruitId_When_GetRecruitParticipants_Then_Success() {
         recruitApplicationService.getRecruitParticipants(1L);
-        assertDoesNotThrow(()->{
-            recruitApplicationService.getRecruitParticipants(1L);
-        });
+        GetRecruitParticipantsResDto dto = recruitApplicationService.getRecruitParticipants(1L);
+
+        assertAll(
+                ()->assertEquals(2, dto.getMembers().size())
+        );
     }
 
     @DisplayName("등록자 리크루트 참여 좋아요 토글")


### PR DESCRIPTION
## Issues

- #88 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
**[등록자 리크루트 참여 -> 리크루트에 등록자의 리크루트 참여 파트 column 추가]**

기존 로직  
```
리크루트 등록 
-> 리크루트 등록
-> 리크루트에서 모집하고자 하는 모집군 인원 제한 등록 (리크루트 등록자를 참여자로 포함하는 인원 수)
-> 리크루트에서 사용하는 기술 스택 등록
-> 리크루트 등록자를 참여하고자하는 모집군의 참여자로 등록 
```

변경된 로직 
```
리크루트 등록 
-> 리크루트 등록 (리크루트 등록자의 모집군은 해당 리크루트에 종속적인 값으로 변경)
-> 리크루트에서 모집하고자 하는 모집군 인원 제한 등록 (리크루트 등록자를 제외한 인원 수)
-> 리크루트에서 사용하는 기술 스택 등록
```

어제 진행된 회의에서 일부 요청 사항으로 인해 테이블에 변경 사항이 있습니다.

1. 등록, 수정하는 시점의 인원 제한은 실제로 등록자가 모집 하고자 하는 인원만 포함시키고, 자기 자신을 포함시키지 않는다.
2. 리크루트를 조회하는 경우, 등록자를 포함한 참여자 명단과, 등록자를 포함한 인원 제한 수를 보여줘야한다.
3. 등록자가 참여하는 모집 타입은 수정이 가능해야한다. 




