### PR TITLE
feat: 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -81,18 +81,9 @@ public class PostController {
     @PutMapping("/{postId}")
     public EnvelopeResponse<Long> updatePost(@Valid @ModelAttribute PostPutUpdateReqDto postPutUpdateReqDto,
                                              @PathVariable Long postId, AuthenticatedMember authenticatedMember) {
-        AuthenticatedMember tempMember = AuthenticatedMember.builder()
-                .memberId(1L)
-                .memberRole("user")
-                .build();
-
-        log.info(postPutUpdateReqDto.getTitle());
-        log.info(postPutUpdateReqDto.getContent());
-        log.info(String.valueOf(postPutUpdateReqDto.isAnonymous()));
-        log.info(postPutUpdateReqDto.getImages().get(0).getOriginalFilename());
 
         return EnvelopeResponse.<Long>builder()
-                .data(postService.updatePost(postId, tempMember.getMemberId(), postPutUpdateReqDto))
+                .data(postService.updatePost(postId, authenticatedMember.getMemberId(), postPutUpdateReqDto))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -1,10 +1,7 @@
 package com.ssafy.ssafsound.domain.post.controller;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
-import com.ssafy.ssafsound.domain.post.dto.GetPostDetailListResDto;
-import com.ssafy.ssafsound.domain.post.dto.GetPostListResDto;
-import com.ssafy.ssafsound.domain.post.dto.PostPostReportReqDto;
-import com.ssafy.ssafsound.domain.post.dto.PostPostWriteReqDto;
+import com.ssafy.ssafsound.domain.post.dto.*;
 import com.ssafy.ssafsound.domain.post.service.PostService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
@@ -78,6 +75,24 @@ public class PostController {
 
         return EnvelopeResponse.<Long>builder()
                 .data(postService.deletePost(postId, authenticatedMember.getMemberId()))
+                .build();
+    }
+
+    @PutMapping("/{postId}")
+    public EnvelopeResponse<Long> updatePost(@Valid @ModelAttribute PostPutUpdateReqDto postPutUpdateReqDto,
+                                             @PathVariable Long postId, AuthenticatedMember authenticatedMember) {
+        AuthenticatedMember tempMember = AuthenticatedMember.builder()
+                .memberId(1L)
+                .memberRole("user")
+                .build();
+
+        log.info(postPutUpdateReqDto.getTitle());
+        log.info(postPutUpdateReqDto.getContent());
+        log.info(String.valueOf(postPutUpdateReqDto.isAnonymous()));
+        log.info(postPutUpdateReqDto.getImages().get(0).getOriginalFilename());
+
+        return EnvelopeResponse.<Long>builder()
+                .data(postService.updatePost(postId, tempMember.getMemberId(), postPutUpdateReqDto))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/domain/Post.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/domain/Post.java
@@ -69,15 +69,9 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post")
     private List<PostScrap> scraps = new ArrayList<>();
 
-    public void setTitle(String title) {
+    public void updatePost(String title, String content, Boolean anonymous){
         this.title = title;
-    }
-
-    public void setContent(String content) {
         this.content = content;
-    }
-
-    public void setAnonymous(Boolean anonymous) {
         this.anonymous = anonymous;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/domain/Post.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/domain/Post.java
@@ -12,9 +12,8 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity(name="post")
+@Entity(name = "post")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -70,4 +69,15 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post")
     private List<PostScrap> scraps = new ArrayList<>();
 
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setAnonymous(Boolean anonymous) {
+        this.anonymous = anonymous;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/domain/Post.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/domain/Post.java
@@ -4,10 +4,7 @@ import com.ssafy.ssafsound.domain.BaseTimeEntity;
 import com.ssafy.ssafsound.domain.board.domain.Board;
 import com.ssafy.ssafsound.domain.comment.domain.Comment;
 import com.ssafy.ssafsound.domain.member.domain.Member;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -17,6 +14,7 @@ import java.util.List;
 
 @Entity(name="post")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -38,6 +36,7 @@ public class Post extends BaseTimeEntity {
     @Column
     private Long view;
 
+    @Builder.Default
     @Column
     private Boolean deletedPost = Boolean.FALSE;
 
@@ -55,15 +54,19 @@ public class Post extends BaseTimeEntity {
     @OneToOne(mappedBy = "post", cascade = CascadeType.REMOVE)
     private HotPost hotPost;
 
+    @Builder.Default
     @OneToMany(mappedBy = "post")
     private List<PostImage> images = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "post")
     private List<PostLike> likes = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "post")
     private List<PostScrap> scraps = new ArrayList<>();
 

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/PostPutUpdateReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/PostPutUpdateReqDto.java
@@ -1,0 +1,31 @@
+package com.ssafy.ssafsound.domain.post.dto;
+
+import com.ssafy.ssafsound.global.validator.CheckFileCount;
+import com.ssafy.ssafsound.global.validator.CheckFileSize;
+import com.ssafy.ssafsound.global.validator.CheckImage;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+@Setter
+public class PostPutUpdateReqDto {
+    @NotBlank
+    @Size(min = 2, max = 100)
+    private String title;
+
+    @NotBlank
+    @Size(min = 2)
+    private String content;
+
+    private boolean anonymous;
+
+    @CheckFileCount(maxFileCount = 10)
+    @CheckFileSize(maxFileSize = 50 * 1024 * 1024)
+    @CheckImage
+    private List<MultipartFile> images;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/exception/PostErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/exception/PostErrorInfo.java
@@ -5,13 +5,15 @@ import lombok.Getter;
 @Getter
 public enum PostErrorInfo {
     NOT_FOUND("802", "게시글을 찾을 수 없습니다."),
-    DUPLICATE_REPORT("803", "이미 신고된 게시글입니다.");
+    DUPLICATE_REPORT("803", "이미 신고된 게시글입니다."),
+    UNAUTHORIZED_DELETE_POST("804", "해당 게시글 삭제 권한이 없습니다."),
+    UNAUTHORIZED_UPDATE_POST("805", "해당 게시글 수정 권한이 없습니다.");
 
 
     private final String code;
     private final String message;
 
-    PostErrorInfo(String code, String message){
+    PostErrorInfo(String code, String message) {
         this.code = code;
         this.message = message;
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -13,9 +13,7 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByBoardId(Long boardId, Pageable pageable);
-
-//    boolean existsByIdAndMemberId(Long id, Long memberId);
-
+    
     @Query("SELECT p FROM post p JOIN FETCH p.member WHERE p.id = :id")
     Optional<Post> findByIdWithMember(@Param("id") Long id);
 

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -16,6 +16,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     boolean existsByIdAndMemberId(Long id, Long memberId);
 
-    @Query("SELECT p FROM post p JOIN FETCH p.member JOIN FETCH p.images WHERE p.id = :id")
+    @Query("SELECT p FROM post p JOIN FETCH p.member LEFT JOIN FETCH p.images WHERE p.id = :id")
     Optional<Post> findByIdWithMemberAndPostImageFetch(@Param("id") Long id);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -14,7 +14,10 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByBoardId(Long boardId, Pageable pageable);
 
-    boolean existsByIdAndMemberId(Long id, Long memberId);
+//    boolean existsByIdAndMemberId(Long id, Long memberId);
+
+    @Query("SELECT p FROM post p JOIN FETCH p.member WHERE p.id = :id")
+    Optional<Post> findByIdWithMember(@Param("id") Long id);
 
     @Query("SELECT p FROM post p JOIN FETCH p.member LEFT JOIN FETCH p.images WHERE p.id = :id")
     Optional<Post> findByIdWithMemberAndPostImageFetch(@Param("id") Long id);

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -3,12 +3,19 @@ package com.ssafy.ssafsound.domain.post.repository;
 import com.ssafy.ssafsound.domain.post.domain.Post;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByBoardId(Long boardId, Pageable pageable);
+
     boolean existsByIdAndMemberId(Long id, Long memberId);
+
+    @Query("SELECT p FROM post p JOIN FETCH p.member JOIN FETCH p.images WHERE p.id = :id")
+    Optional<Post> findByIdWithMemberAndPostImageFetch(@Param("id") Long id);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -244,9 +244,7 @@ public class PostService {
         }
 
         // 1. 수정
-        post.setTitle(postPutUpdateReqDto.getTitle());
-        post.setContent(postPutUpdateReqDto.getContent());
-        post.setAnonymous(postPutUpdateReqDto.isAnonymous());
+        post.updatePost(postPutUpdateReqDto.getTitle(), postPutUpdateReqDto.getContent(), postPutUpdateReqDto.isAnonymous());
 
         // 2. 새 이미지 업로드
         if (!postPutUpdateReqDto.getImages().get(0).isEmpty())

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -223,12 +223,15 @@ public class PostService {
     }
 
     public Long deletePost(Long postId, Long memberId) {
-        if (!postRepository.existsByIdAndMemberId(postId, memberId)) {
-            throw new PostException(PostErrorInfo.NOT_FOUND);
+        Post post = postRepository.findByIdWithMember(postId)
+                .orElseThrow(() -> new PostException(PostErrorInfo.NOT_FOUND));
+
+        if (post.getMember().getId().equals(memberId)) {
+            throw new PostException((PostErrorInfo.UNAUTHORIZED_DELETE_POST));
         }
 
-        postRepository.deleteById(postId);
-        return postId;
+        postRepository.delete(post);
+        return post.getId();
     }
 
     @Transactional
@@ -251,8 +254,8 @@ public class PostService {
 
         // 3. 기존 이미지 삭제
         if (post.getImages().size() >= 1)
-        deletePostImages(post.getImages());
+            deletePostImages(post.getImages());
 
-        return postId;
+        return post.getId();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -226,7 +226,7 @@ public class PostService {
         Post post = postRepository.findByIdWithMember(postId)
                 .orElseThrow(() -> new PostException(PostErrorInfo.NOT_FOUND));
 
-        if (post.getMember().getId().equals(memberId)) {
+        if (!post.getMember().getId().equals(memberId)) {
             throw new PostException((PostErrorInfo.UNAUTHORIZED_DELETE_POST));
         }
 


### PR DESCRIPTION
## Issues

- #77 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 게시글 수정 기능 구현
- 게시글 삭제 쿼리 복구
- 예외 처리

게시글 수정과 게시글 삭제에서 게시글 정보를 가져오는 쿼리에 Fetch join을 적용하고
이후에 memberId와 비교한 이유는 사용자 권한 예외를 발생하기 위함입니다.

memberId와 함께 post정보를 불러오면 작성자가 아닌 사용자는 게시글 정보가 나오지 않기 때문에
권한이 없는 사용자가 접근했을때 예외를 처리할 방법이 없어지게 됩니다.

예시로) 기존 방법은 게시글이 있는 번호를 넘겨줬을 때 "게시글이 존재하지 않습니다" 라는 에러를 보게 됩니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->
## 기타
JPA 쿼리와 게시글 수정 흐름을 위주로 리뷰해주시면 감사하겠습니다.

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
