### PR TITLE
test: memberService With JaCoCo

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/dto/AuthenticatedMember.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/dto/AuthenticatedMember.java
@@ -15,7 +15,7 @@ public class AuthenticatedMember {
 
     private String memberRole;
 
-    public static AuthenticatedMember of(Member member) {
+    public static AuthenticatedMember from(Member member) {
         return AuthenticatedMember.builder()
                 .memberId(member.getId())
                 .memberRole(member.getRole().getRoleType())

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -79,7 +79,7 @@ public class AuthService {
     public CreateMemberAccessTokenResDto reissueAccessToken(Long memberId) {
         MemberToken memberToken = memberTokenRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_TOKEN_NOT_FOUND));
         Member member = memberToken.getMember();
-        String accessToken = jwtTokenProvider.createAccessToken(AuthenticatedMember.of(member));
+        String accessToken = jwtTokenProvider.createAccessToken(AuthenticatedMember.from(member));
         memberToken.changeAccessTokenByRefreshToken(accessToken);
         memberTokenRepository.save(memberToken);
         return CreateMemberAccessTokenResDto.of(accessToken);

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -79,5 +79,6 @@ public class Member extends BaseTimeEntity {
     public void setGeneralMemberInformation(PostMemberInfoReqDto postMemberInfoReqDto) {
         this.nickname = postMemberInfoReqDto.getNickname();
         this.ssafyMember = postMemberInfoReqDto.getSsafyMember();
+        this.major = postMemberInfoReqDto.getIsMajor();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberResDto.java
@@ -17,6 +17,7 @@ public class GetMemberResDto {
     private String memberRole;
     private String nickname;
     private Boolean ssafyMember;
+    private Boolean isMajor;
     private SSAFYInfo ssafyInfo;
 
     public static GetMemberResDto fromGeneralUser(Member member, MemberRole memberRole) {
@@ -25,6 +26,7 @@ public class GetMemberResDto {
                 .memberRole(memberRole.getRoleType())
                 .nickname(member.getNickname())
                 .ssafyMember(member.getSsafyMember())
+                .isMajor(member.getMajor())
                 .build();
     }
 
@@ -34,9 +36,9 @@ public class GetMemberResDto {
                 .memberRole(memberRole.getRoleType())
                 .nickname(member.getNickname())
                 .ssafyMember(member.getSsafyMember())
+                .isMajor(member.getMajor())
                 .ssafyInfo(SSAFYInfo.builder()
                         .semester(member.getSemester())
-                        .isMajor(member.getMajor())
                         .campus(member.getCampus().getName())
                         .build())
                 .build();

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
@@ -25,6 +25,7 @@ public class PostMemberInfoReqDto {
     @Semester
     private Integer semester;
 
+    @NotNull
     private Boolean isMajor;
 
     private String campus;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
@@ -1,12 +1,17 @@
 package com.ssafy.ssafsound.domain.member.dto;
 
 import com.ssafy.ssafsound.domain.member.validator.Semester;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class PostMemberInfoReqDto {
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberReqDto.java
@@ -4,12 +4,16 @@ package com.ssafy.ssafsound.domain.member.dto;
 import com.ssafy.ssafsound.domain.member.domain.AccountState;
 import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.OAuthType;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class PostMemberReqDto {
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/SSAFYInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/SSAFYInfo.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 public class SSAFYInfo {
 
     private Integer semester;
-    private boolean isMajor;
     private String campus;
     private String certificationState;
     private String majorType;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -114,14 +114,14 @@ public class MemberService {
     }
 
     public boolean isNotInputMemberInformation(Member member) {
-        return member.getSsafyMember() == null && member.getNickname() == null;
+        return member.getSsafyMember() == null && member.getNickname() == null && member.getMajor() == null;
     }
 
     public boolean isGeneralMemberInformation(Member member) {
-        return !member.getSsafyMember() && member.getNickname() != null;
+        return !member.getSsafyMember() && member.getNickname() != null && member.getMajor() != null;
     }
 
     public boolean isSSAFYMemberInformation(Member member) {
-        return member.getSsafyMember() && member.getNickname() != null;
+        return member.getSsafyMember() && member.getNickname() != null && member.getMajor() != null;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -33,15 +33,14 @@ public class MemberService {
         Member member;
         if (optionalMember.isPresent()) {
             member = optionalMember.get();
-            if (isInvalidOauthLogin(member, postMemberReqDto))
-                throw new MemberException(MemberErrorInfo.MEMBER_OAUTH_NOT_FOUND);
+            if (isInvalidOauthLogin(member, postMemberReqDto)) throw new MemberException(MemberErrorInfo.MEMBER_OAUTH_NOT_FOUND);
+            return AuthenticatedMember.from(member);
         } else {
             MemberRole memberRole = findMemberRoleByRoleName("user");
             member = postMemberReqDto.createMember();
             member.setMemberRole(memberRole);
-            memberRepository.save(member);
+            return AuthenticatedMember.from(memberRepository.save(member));
         }
-        return AuthenticatedMember.of(member);
     }
 
     @Transactional
@@ -60,7 +59,7 @@ public class MemberService {
                     .refreshToken(refreshToken)
                     .member(member)
                     .build();
-            
+
             memberTokenRepository.save(memberToken);
         }
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -60,8 +60,9 @@ public class MemberService {
                     .refreshToken(refreshToken)
                     .member(member)
                     .build();
+            
+            memberTokenRepository.save(memberToken);
         }
-        memberTokenRepository.save(memberToken);
     }
 
     @Transactional

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitApplicationElement.java
@@ -28,6 +28,9 @@ public class RecruitApplicationElement {
     private String nickName;
 
     @JsonProperty
+    private Boolean isMajor;
+
+    @JsonProperty
     private SSAFYInfo ssafyInfo;
 
     @JsonProperty
@@ -51,9 +54,9 @@ public class RecruitApplicationElement {
         this.type = type;
         this.memberId = memberId;
         this.nickName = nickName;
+        this.isMajor = major;
         this.ssafyInfo = SSAFYInfo.builder()
                 .semester(semester)
-                .isMajor(major)
                 .campus(campus == null ? null : campus.getName())
                 .certificationState(certificationState == null ? null : certificationState.name())
                 .majorType(majorType)

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import com.ssafy.ssafsound.domain.member.domain.OAuthType;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PostNicknameReqDto;
+import com.ssafy.ssafsound.domain.member.dto.PostNicknameResDto;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
@@ -244,5 +245,33 @@ class MemberServiceTest {
         member.setSSAFYMemberInformation(postMemberInfoReqDto, metaDataConsumer);
 
         assertTrue(memberService.isSSAFYMemberInformation(member));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임이라면 닉네임 중복이라는 예외가 발생한다.")
+    void Given_Nickname_When_ExistNickname_Then_ThrowMemberException() {
+        PostNicknameReqDto postNicknameReqDto = new PostNicknameReqDto("taeyong");
+        given(memberRepository.existsByNickname(postNicknameReqDto.getNickname())).willReturn(true);
+
+        assertThrows(MemberException.class, () -> memberService.checkNicknamePossible(postNicknameReqDto));
+
+        verify(memberRepository).existsByNickname(eq("taeyong"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 닉네임이라면 닉네임 사용을 할 수 있는 dto를 반환한다.")
+    void Given_Nickname_When_NotExistNickname_Then_ReturnTrue() {
+        PostNicknameReqDto postNicknameReqDto = new PostNicknameReqDto("taeyong");
+        PostNicknameResDto postNicknameResDto = PostNicknameResDto.builder()
+                .possible(true)
+                .build();
+
+        given(memberRepository.existsByNickname(postNicknameReqDto.getNickname())).willReturn(false);
+
+        PostNicknameResDto result = memberService.checkNicknamePossible(postNicknameReqDto);
+
+        assertThat(result.isPossible()).isEqualTo(postNicknameResDto.isPossible());
+
+        verify(memberRepository).existsByNickname(eq("taeyong"));
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -274,7 +274,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원가입 이후 정보 입력을 하지 않았다면 닉네임과 싸피멤버여부에 대해 null을 가진 dto를 반환한다.")
-    void Given_Member_When_NotInputInformation_Then_ReturnDtoWithNullNicknameAndSSafyMember() {
+    void Given_Member_When_GetMemberInfo_Then_Success() {
         GetMemberResDto getMemberResDto = GetMemberResDto.fromGeneralUser(member, member.getRole());
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
 
@@ -292,7 +292,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원가입 이후 싸피유저가 아닌 일반 유저에 대해 정보 입력을 했다면 일반 유저 dto를 반환한다.")
-    void Given_Member_When_InputGeneralInformation_Then_ReturnDtoWIthNicknameAndGeneralMember() {
+    void Given_Member_When_GetGeneralMemberInfo_Then_Success() {
         member.setGeneralMemberInformation(generalMemberInfoReqDto);
         GetMemberResDto getMemberResDto = GetMemberResDto.fromGeneralUser(member, member.getRole());
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
@@ -311,7 +311,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원가입 이후 싸피유저에 대한 정보 입력을 했다면 싸피 유저 dto를 반환한다.")
-    void Given_Member_When_InputSSAFYInformation_Then_ReturnDtoWithNicknameAndSSAFYMember() {
+    void Given_Member_When_GetSSAFYMemberInfo_Then_Success() {
         given(metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), SSAFYMemberInfoReqDto.getCampus())).willReturn(new MetaData(Campus.SEOUL));
         member.setSSAFYMemberInformation(SSAFYMemberInfoReqDto, metaDataConsumer);
         GetMemberResDto getMemberResDto = GetMemberResDto.fromSSAFYUser(member, member.getRole());

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafsound.domain.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberServiceTest {
+
+}

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberRole;
 import com.ssafy.ssafsound.domain.member.domain.OAuthType;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
+import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
@@ -21,6 +22,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -89,5 +91,26 @@ class MemberServiceTest {
         verify(memberRepository).findByOauthIdentifier(eq(postMemberReqDto.getOauthIdentifier()));
         verify(memberRoleRepository).findByRoleType(eq("user"));
         verify(memberRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하는 Oauth Identifier와 일치한다면 해당 멤버를 가져옵니다.")
+    void Given_ExistOauthIdentifier_When_FindMember_Then_Success() {
+        AuthenticatedMember authenticatedMemberReq = AuthenticatedMember.builder()
+                .memberId(member.getId())
+                .memberRole(member.getRole().getRoleType())
+                .build();
+
+        //when
+        given(memberRepository.findByOauthIdentifier(postMemberReqDto.getOauthIdentifier())).willReturn(Optional.of(member));
+        AuthenticatedMember authenticatedMemberRes = memberService.createMemberByOauthIdentifier(postMemberReqDto);
+
+        //then
+        assertAll(
+                () -> assertThat(authenticatedMemberRes.getMemberId()).isEqualTo(authenticatedMemberReq.getMemberId()),
+                () -> assertThat(authenticatedMemberRes.getMemberRole()).isEqualTo(authenticatedMemberReq.getMemberRole())
+        );
+
+        verify(memberRepository).findByOauthIdentifier(eq(postMemberReqDto.getOauthIdentifier()));
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -6,7 +6,9 @@ import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberRole;
 import com.ssafy.ssafsound.domain.member.domain.MemberToken;
 import com.ssafy.ssafsound.domain.member.domain.OAuthType;
+import com.ssafy.ssafsound.domain.member.dto.PostMemberInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
+import com.ssafy.ssafsound.domain.member.dto.PostNicknameReqDto;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
@@ -24,8 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -186,5 +187,62 @@ class MemberServiceTest {
 
         verify(memberTokenRepository).findById(authenticatedMember.getMemberId());
         verify(memberRepository).findById(authenticatedMember.getMemberId());
+    }
+
+    @Test
+    @DisplayName("멤버가 싸피멤버라는 질문에 대해 null을 가지고 있고 닉네임도 null이라면 정보를 입력한지 검사하는 메서드에 대해 True를 반환한다.")
+    void Given_Member_When_NotInputInformation_Then_ReturnTrue() {
+        assertTrue(memberService.isNotInputMemberInformation(member));
+    }
+
+    @Test
+    @DisplayName("멤버가 닉네임이나 싸피 멤버라는 질문에 대해 값을 가지고 있다면 정보를 입력한지 검사하는 메서드에 대해 False를 반환한다.")
+    void Given_Member_when_InputInformation_Then_ReturnFalse() {
+        PostMemberInfoReqDto postMemberInfoReqDto = PostMemberInfoReqDto.builder()
+                .ssafyMember(false)
+                .nickname("taeyong")
+                .build();
+        member.setGeneralMemberInformation(postMemberInfoReqDto);
+
+        assertFalse(memberService.isNotInputMemberInformation(member));
+    }
+
+    @Test
+    @DisplayName("일반 멤버이고 닉네임을 가지고 있다면 일반유저인지 확인하는 메서드에서 Trye를 반환한다.")
+    void Given_Member_When_InputGeneralMember_Then_ReturnTrue() {
+        PostMemberInfoReqDto postMemberInfoReqDto = PostMemberInfoReqDto.builder()
+                .ssafyMember(false)
+                .nickname("taeyong")
+                .build();
+
+        member.setGeneralMemberInformation(postMemberInfoReqDto);
+
+        assertTrue(memberService.isGeneralMemberInformation(member));
+    }
+
+    @Test
+    @DisplayName("멤버가 싸피 멤버이고 닉네임을 가지고 있다면 일반유저인지 확인하는 메서드에서 False를 반환한다.")
+    void Given_Member_When_InputSSAFYMember_Then_ReturnFalse() {
+        PostMemberInfoReqDto postMemberInfoReqDto = PostMemberInfoReqDto.builder()
+                .ssafyMember(true)
+                .nickname("taeyong")
+                .build();
+
+        member.setSSAFYMemberInformation(postMemberInfoReqDto, metaDataConsumer);
+
+        assertFalse(memberService.isGeneralMemberInformation(member));
+    }
+
+    @Test
+    @DisplayName("멤버가 싸피 멤버이고 닉네임을 가지고 있다면 싸피유저인지 확인하는 메서드에서 True를 반환한다.")
+    void Given_Member_When_InputSSAFYMember_Then_ReturnTrue() {
+        PostMemberInfoReqDto postMemberInfoReqDto = PostMemberInfoReqDto.builder()
+                .ssafyMember(true)
+                .nickname("taeyong")
+                .build();
+
+        member.setSSAFYMemberInformation(postMemberInfoReqDto, metaDataConsumer);
+
+        assertTrue(memberService.isSSAFYMemberInformation(member));
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -171,4 +171,20 @@ class MemberServiceTest {
 
         verify(memberTokenRepository).findById(authenticatedMember.getMemberId());
     }
+
+    @Test
+    @DisplayName("가입이 안된 Member라면 토큰 발급을 시도하면 예외가 발생한다.")
+    void Given_Member_When_NotJoinedMember_Then_ThrowMemberException() {
+        AuthenticatedMember authenticatedMember = AuthenticatedMember.from(member);
+        String accessToken = jwtTokenProvider.createAccessToken(authenticatedMember);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authenticatedMember);
+
+        given(memberTokenRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.empty());
+        given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.empty());
+
+        assertThrows(MemberException.class, () -> memberService.saveTokenByMember(authenticatedMember, accessToken, refreshToken));
+
+        verify(memberTokenRepository).findById(authenticatedMember.getMemberId());
+        verify(memberRepository).findById(authenticatedMember.getMemberId());
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -113,4 +113,17 @@ class MemberServiceTest {
 
         verify(memberRepository).findByOauthIdentifier(eq(postMemberReqDto.getOauthIdentifier()));
     }
+
+    @Test
+    @DisplayName("존재하는 Oauth Identifier를 가져왔지만 요청된 정보와 일치하지 않다면 예외를 던진다.")
+    void Given_OauthIdentifier_When_CompareIncorrectRequest_Then_ThrowException() {
+        PostMemberReqDto testPostMemberReqDto = PostMemberReqDto.builder()
+                .oauthName("kakao")
+                .oauthIdentifier(postMemberReqDto.getOauthIdentifier())
+                .build();
+
+        given(memberRepository.findByOauthIdentifier(postMemberReqDto.getOauthIdentifier())).willReturn(Optional.of(member));
+
+        assertThrows(MemberException.class, () -> memberService.createMemberByOauthIdentifier(testPostMemberReqDto));
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -1,7 +1,93 @@
 package com.ssafy.ssafsound.domain.member.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.domain.MemberRole;
+import com.ssafy.ssafsound.domain.member.domain.OAuthType;
+import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
+import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
+import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
+import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
+import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private MemberRoleRepository memberRoleRepository;
+    @Mock
+    private MemberTokenRepository memberTokenRepository;
+    @Mock
+    private MetaDataConsumer metaDataConsumer;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @InjectMocks
+    private MemberService memberService;
+    PostMemberReqDto postMemberReqDto;
+    Member member;
+    MemberRole memberRole;
+
+    @BeforeEach
+    void setUp() {
+        postMemberReqDto = PostMemberReqDto.builder()
+                .oauthName("github")
+                .oauthIdentifier("1232312312312")
+                .build();
+
+        memberRole = MemberRole.builder()
+                .id(1)
+                .roleType("user")
+                .build();
+
+        member = Member.builder()
+                .oauthType(OAuthType.valueOf(postMemberReqDto.getOauthName().toUpperCase()))
+                .oauthIdentifier(postMemberReqDto.getOauthIdentifier())
+                .id(1L)
+                .role(memberRole)
+                .build();
+    }
+
+    @Test
+    @DisplayName("새로운 Oauth Identifier가 주어졌다면 멤버를 저장하는데 성공합니다.")
+    void Given_OauthIdentifier_When_SaveMember_Then_Success() {
+        AuthenticatedMember authenticatedMemberReq = AuthenticatedMember.builder()
+                .memberId(member.getId())
+                .memberRole(member.getRole().getRoleType())
+                .build();
+
+        //given Mock Stub
+        given(memberRepository.findByOauthIdentifier(postMemberReqDto.getOauthIdentifier())).willReturn(Optional.empty());
+        given(memberRoleRepository.findByRoleType("user")).willReturn(Optional.of(memberRole));
+        given(memberRepository.save(argThat(member -> member.getOauthIdentifier().equals("1232312312312")))).willReturn(member);
+
+        //when
+        AuthenticatedMember authenticatedMemberRes = memberService.createMemberByOauthIdentifier(postMemberReqDto);
+
+        //then
+        assertAll(
+                () -> assertThat(authenticatedMemberRes.getMemberId()).isEqualTo(authenticatedMemberReq.getMemberId()),
+                () -> assertThat(authenticatedMemberRes.getMemberRole()).isEqualTo(authenticatedMemberReq.getMemberRole())
+        );
+
+        //verify
+        verify(memberRepository).findByOauthIdentifier(eq(postMemberReqDto.getOauthIdentifier()));
+        verify(memberRoleRepository).findByRoleType(eq("user"));
+        verify(memberRepository).save(any());
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -154,4 +154,21 @@ class MemberServiceTest {
         verify(memberTokenRepository).findById(authenticatedMember.getMemberId());
         verify(memberRepository).findById(authenticatedMember.getMemberId());
     }
+
+    @Test
+    @DisplayName("Member가 토큰을 발급한 적이 있다면 새로운 토큰들로 저장한다.")
+    void Given_Tokens_When_JoinedMember_Then_SuccessExchangeTokens() {
+        AuthenticatedMember authenticatedMember = AuthenticatedMember.from(member);
+        String accessToken = jwtTokenProvider.createAccessToken(authenticatedMember);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authenticatedMember);
+        MemberToken memberToken = MemberToken.builder()
+                .member(member)
+                .build();
+
+        given(memberTokenRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(memberToken));
+
+        memberService.saveTokenByMember(authenticatedMember, accessToken, refreshToken);
+
+        verify(memberTokenRepository).findById(authenticatedMember.getMemberId());
+    }
 }


### PR DESCRIPTION
## Issues

- #87 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
- 영속성 컨텍스트에 대해 이해하지 못하고 save()했던 위치를 수정했습니다.
-  Test Code 구현 중, isMajor인 전공 여부에 대해 SSAFYInfo Dto에서 제거하고 기본 ResDto 필드에 추가했습니다.
- Mocking Stub에 대한 verify를 전부 진행했습니다.
- save 시점의 상태를 확인하기 위해 ArgumentCaptor를 활용했습니다.
- 테스트 코드 작성 중 비즈니스 로직에서  from, of, to 등 잘못 작성한 메서드 네이밍을 수정했습니다.

의존성에 대해서 given().willReturn()을 통해 Stub를 이용했습니다.

---
***중요***
Test Code를 읽는데 수월한 방법은 memberService를 통해 호출하는 method와 해당 테스트 코드를 비교하면 비교적 짧은 시간 안에 이해할 수 있다고 생각합니다.
<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷
<img width="917" alt="스크린샷 2023-06-30 오전 1 36 30" src="https://github.com/SSAF-SOUND/ssaf-sound-be/assets/86272688/44ca5cb1-38d6-4998-a393-441dbc28c389">

60% 이상의 Coverage는 보여주고 있습니다.

하지만 Branch Coverage에서 시간을 많이 쏟아서 추후 리팩토링 예정입니다.
<img width="1172" alt="스크린샷 2023-06-30 오전 1 40 53" src="https://github.com/SSAF-SOUND/ssaf-sound-be/assets/86272688/59dc1952-341e-4297-a4cf-bf661c56fbd5">


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
