### PR TITLE
feat: 댓글 작성 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/controller/CommentController.java
@@ -21,14 +21,9 @@ public class CommentController {
     public EnvelopeResponse<Long> writeComment(@RequestParam Long postId,
                                                @Valid @RequestBody PostCommentWriteReqDto postCommentWriteReqDto,
                                                AuthenticatedMember authenticatedMember) {
-        AuthenticatedMember member = AuthenticatedMember.builder()
-                .memberId(1L)
-                .memberRole("user")
-                .build();
-
 
         return EnvelopeResponse.<Long>builder()
-                .data(commentService.writeComment(postId, member.getMemberId(), postCommentWriteReqDto))
+                .data(commentService.writeComment(postId, authenticatedMember.getMemberId(), postCommentWriteReqDto))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/controller/CommentController.java
@@ -1,0 +1,34 @@
+package com.ssafy.ssafsound.domain.comment.controller;
+
+import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import com.ssafy.ssafsound.domain.comment.dto.PostCommentWriteReqDto;
+import com.ssafy.ssafsound.domain.comment.service.CommentService;
+import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping
+    public EnvelopeResponse<Long> writeComment(@RequestParam Long postId,
+                                               @Valid @RequestBody PostCommentWriteReqDto postCommentWriteReqDto,
+                                               AuthenticatedMember authenticatedMember) {
+        AuthenticatedMember member = AuthenticatedMember.builder()
+                .memberId(1L)
+                .memberRole("user")
+                .build();
+
+
+        return EnvelopeResponse.<Long>builder()
+                .data(commentService.writeComment(postId, member.getMemberId(), postCommentWriteReqDto))
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/domain/Comment.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/domain/Comment.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity(name="comment")
+@Entity(name = "comment")
 @Getter
 @Builder
 @NoArgsConstructor
@@ -28,10 +28,21 @@ public class Comment extends BaseTimeEntity {
     private String content;
 
     @Column
-    private Boolean deletedComment;
+    private Boolean parent;
 
-    @OneToMany(mappedBy = "commentGroup")
-    private List<Comment> replies = new ArrayList<>();
+    @Column
+    @Builder.Default
+    private Boolean deletedComment = Boolean.FALSE;
+
+    @Column
+    private Boolean anonymous;
+
+//    @OneToMany(mappedBy = "commentGroup")
+//    private List<Comment> replies = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "comment_number_id")
+    private CommentNumber commentNumber;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_group", referencedColumnName = "comment_id", updatable = false)
@@ -44,4 +55,5 @@ public class Comment extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/domain/Comment.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/domain/Comment.java
@@ -28,9 +28,6 @@ public class Comment extends BaseTimeEntity {
     private String content;
 
     @Column
-    private Boolean parent;
-
-    @Column
     @Builder.Default
     private Boolean deletedComment = Boolean.FALSE;
 
@@ -45,7 +42,7 @@ public class Comment extends BaseTimeEntity {
     private CommentNumber commentNumber;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_group", referencedColumnName = "comment_id", updatable = false)
+    @JoinColumn(name = "comment_group", referencedColumnName = "comment_id")
     private Comment commentGroup;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -56,4 +53,8 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+
+    public void setCommentGroup(Comment commentGroup) {
+        this.commentGroup = commentGroup;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/domain/CommentNumber.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/domain/CommentNumber.java
@@ -1,0 +1,36 @@
+package com.ssafy.ssafsound.domain.comment.domain;
+
+import com.ssafy.ssafsound.domain.BaseTimeEntity;
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.post.domain.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity(name = "comment_number")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentNumber extends BaseTimeEntity {
+    @Id
+    @Column(name = "comment_number_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column
+    private Long number;
+
+
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/dto/PostCommentWriteReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/dto/PostCommentWriteReqDto.java
@@ -1,0 +1,14 @@
+package com.ssafy.ssafsound.domain.comment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+public class PostCommentWriteReqDto {
+    @Size(min = 2)
+    private String content;
+    private Boolean anonymous;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/exception/CommentErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/exception/CommentErrorInfo.java
@@ -1,0 +1,16 @@
+package com.ssafy.ssafsound.domain.comment.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum CommentErrorInfo {
+    NOT_FOUND_COMMENT_NUMBER("806", "익명 번호를 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+
+    CommentErrorInfo(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/exception/CommentException.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/exception/CommentException.java
@@ -1,0 +1,10 @@
+package com.ssafy.ssafsound.domain.comment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentException extends RuntimeException{
+    private CommentErrorInfo info;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentNumberRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentNumberRepository.java
@@ -1,0 +1,17 @@
+package com.ssafy.ssafsound.domain.comment.repository;
+
+import com.ssafy.ssafsound.domain.comment.domain.CommentNumber;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CommentNumberRepository extends JpaRepository<CommentNumber, Long> {
+    Boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    long countAllByPostId(Long postId);
+
+    Optional<CommentNumber> findByPostIdAndMemberId(Long postId, Long memberId);
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentNumberRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentNumberRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface CommentNumberRepository extends JpaRepository<CommentNumber, Long> {
-    Boolean existsByPostIdAndMemberId(Long postId, Long memberId);
-
     long countAllByPostId(Long postId);
 
     Optional<CommentNumber> findByPostIdAndMemberId(Long postId, Long memberId);

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentNumberRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentNumberRepository.java
@@ -4,7 +4,6 @@ import com.ssafy.ssafsound.domain.comment.domain.CommentNumber;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.comment.repository;
+
+import com.ssafy.ssafsound.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/service/CommentService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/service/CommentService.java
@@ -1,0 +1,62 @@
+package com.ssafy.ssafsound.domain.comment.service;
+
+import com.ssafy.ssafsound.domain.comment.domain.Comment;
+import com.ssafy.ssafsound.domain.comment.domain.CommentNumber;
+import com.ssafy.ssafsound.domain.comment.dto.PostCommentWriteReqDto;
+import com.ssafy.ssafsound.domain.comment.exception.CommentErrorInfo;
+import com.ssafy.ssafsound.domain.comment.exception.CommentException;
+import com.ssafy.ssafsound.domain.comment.repository.CommentNumberRepository;
+import com.ssafy.ssafsound.domain.comment.repository.CommentRepository;
+import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
+import com.ssafy.ssafsound.domain.post.exception.PostErrorInfo;
+import com.ssafy.ssafsound.domain.post.exception.PostException;
+import com.ssafy.ssafsound.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final CommentNumberRepository commentNumberRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+
+    @Transactional
+    public Long writeComment(Long postId, Long memberId, PostCommentWriteReqDto postCommentWriteReqDto) {
+        if (!postRepository.existsById(postId)) {
+            throw new PostException(PostErrorInfo.NOT_FOUND_POST);
+        }
+
+        // 1. 익명 번호 부여
+        CommentNumber commentNumber = commentNumberRepository.
+                findByPostIdAndMemberId(postId, memberId).orElse(null);
+
+        if (commentNumber == null) {
+            commentNumber = CommentNumber.builder()
+                    .post(postRepository.getReferenceById(postId))
+                    .member(memberRepository.getReferenceById(memberId))
+                    .number(commentNumberRepository.countAllByPostId(postId) + 1)
+                    .build();
+            commentNumberRepository.save(commentNumber);
+        }
+
+        // 2. 댓글 저장
+        Comment comment = Comment.builder()
+                .post(postRepository.getReferenceById(postId))
+                .member(memberRepository.getReferenceById(memberId))
+                .content(postCommentWriteReqDto.getContent())
+                .parent(true)
+                .anonymous(postCommentWriteReqDto.getAnonymous())
+                .commentNumber(commentNumber)
+                .commentGroup(null)
+                .build();
+
+        return commentRepository.save(comment).getId();
+    }
+
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/service/CommentService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/service/CommentService.java
@@ -50,13 +50,15 @@ public class CommentService {
                 .post(postRepository.getReferenceById(postId))
                 .member(memberRepository.getReferenceById(memberId))
                 .content(postCommentWriteReqDto.getContent())
-                .parent(true)
                 .anonymous(postCommentWriteReqDto.getAnonymous())
                 .commentNumber(commentNumber)
                 .commentGroup(null)
                 .build();
 
-        return commentRepository.save(comment).getId();
+        comment = commentRepository.save(comment);
+        comment.setCommentGroup(comment);
+
+        return comment.getId();
     }
 
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/comment/service/CommentService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/comment/service/CommentService.java
@@ -3,8 +3,6 @@ package com.ssafy.ssafsound.domain.comment.service;
 import com.ssafy.ssafsound.domain.comment.domain.Comment;
 import com.ssafy.ssafsound.domain.comment.domain.CommentNumber;
 import com.ssafy.ssafsound.domain.comment.dto.PostCommentWriteReqDto;
-import com.ssafy.ssafsound.domain.comment.exception.CommentErrorInfo;
-import com.ssafy.ssafsound.domain.comment.exception.CommentException;
 import com.ssafy.ssafsound.domain.comment.repository.CommentNumberRepository;
 import com.ssafy.ssafsound.domain.comment.repository.CommentRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberRepository;

--- a/src/main/java/com/ssafy/ssafsound/global/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/com/ssafy/ssafsound/global/advice/ExceptionControllerAdvice.java
@@ -3,6 +3,7 @@ package com.ssafy.ssafsound.global.advice;
 
 import com.ssafy.ssafsound.domain.auth.exception.AuthException;
 import com.ssafy.ssafsound.domain.board.exception.BoardException;
+import com.ssafy.ssafsound.domain.comment.exception.CommentException;
 import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitException;
@@ -156,6 +157,17 @@ public class ExceptionControllerAdvice {
         return EnvelopeResponse.builder()
                 .code(GlobalErrorInfo.BAD_REQUEST.getCode())
                 .message(e.getBindingResult().getAllErrors().get(0).getDefaultMessage())
+                .build();
+    }
+
+    @ExceptionHandler(CommentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public EnvelopeResponse CommentExceptionHandler(CommentException e) {
+        log.error(e.getMessage());
+
+        return EnvelopeResponse.builder()
+                .code(e.getInfo().getCode())
+                .message(e.getInfo().getMessage())
                 .build();
     }
 }


### PR DESCRIPTION
## Issues

- #92 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 댓글 작성 기능 구현
- 익명 번호를 부여하기 위한 comment_number 테이블 생성
- comment 익명여부, 댓글 번호 fk 추가

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->
익명1, 익명2, 익명3을 위해서 댓글 번호 테이블 및 엔티티를 추가하였고, 이를 댓글마다 join하기 위해 ManyToOne관계를 댓글 엔티티에 추가했습니다.

댓글 기능의 전체적인 구현 시나리오는 다음과 같습니다.

- 댓글 작성
1. 댓글 번호 테이블에 (postid, memberid)에 해당하는 데이터가 없으면, comment_number에 데이터개수 + 1로 추가(익명번호)
2. commentGroup은 자기자신

- 대댓글 작성
1. 댓글 작성과 동일
2. commentGroup은 쿼리스트링으로 들어온 getReferenceById(commentId)로 채움

- 댓글 목록 조회
1. 댓글, 대댓글 관계없이 댓글 전체를 (id, Group_id)로 정렬해서 조회(replies 리스트 사용x)
2. Pageable을 활용한 페이지네이션
3. 댓글, 대댓글 구분은 id와 commentGroupId가 같으면 부모, 다르면 대댓글

## 기타
커밋이 꼬여버려서 다시 pr 올립니다. 코드는 동일하지만, 이전 피드백은 수정된 상태입니다.
<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
