### PR TITLE
feat: 게시글 검색 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -106,10 +106,10 @@ public class PostController {
     }
 
     @GetMapping("/search")
-    public EnvelopeResponse<GetPostSearchResDto> searchPosts(@RequestParam Long boardId, @RequestParam String keyword, Pageable pageable) {
+    public EnvelopeResponse<GetPostSearchResDto> searchPosts(@Valid GetPostSearchReqDto getPostSearchReqDto, Pageable pageable) {
 
         return EnvelopeResponse.<GetPostSearchResDto>builder()
-                .data(postService.searchPosts(boardId, keyword, pageable))
+                .data(postService.searchPosts(getPostSearchReqDto.getBoardId(), getPostSearchReqDto.getKeyword(), pageable))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -91,17 +91,25 @@ public class PostController {
 
     @GetMapping("/hot")
     public EnvelopeResponse<GetPostHotResDto> findHotPosts(Pageable pageable) {
-        
+
         return EnvelopeResponse.<GetPostHotResDto>builder()
                 .data(postService.findHotPosts(pageable))
                 .build();
     }
 
     @GetMapping("/my")
-    public EnvelopeResponse findMyPosts(Pageable pageable, AuthenticatedMember authenticatedMember){
+    public EnvelopeResponse findMyPosts(Pageable pageable, AuthenticatedMember authenticatedMember) {
 
         return EnvelopeResponse.builder()
                 .data(postService.findMyPosts(pageable, authenticatedMember.getMemberId()))
+                .build();
+    }
+
+    @GetMapping("/search")
+    public EnvelopeResponse<GetPostSearchResDto> searchPosts(@RequestParam Long boardId, @RequestParam String keyword, Pageable pageable) {
+
+        return EnvelopeResponse.<GetPostSearchResDto>builder()
+                .data(postService.searchPosts(boardId, keyword, pageable))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -98,9 +98,9 @@ public class PostController {
     }
 
     @GetMapping("/my")
-    public EnvelopeResponse findMyPosts(Pageable pageable, AuthenticatedMember authenticatedMember) {
+    public EnvelopeResponse<GetPostMyResDto> findMyPosts(Pageable pageable, AuthenticatedMember authenticatedMember) {
 
-        return EnvelopeResponse.builder()
+        return EnvelopeResponse.<GetPostMyResDto>builder()
                 .data(postService.findMyPosts(pageable, authenticatedMember.getMemberId()))
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchElement.java
@@ -1,0 +1,49 @@
+package com.ssafy.ssafsound.domain.post.dto;
+
+import com.ssafy.ssafsound.domain.post.domain.Post;
+import com.ssafy.ssafsound.domain.post.domain.PostImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GetPostSearchElement {
+    private String boardTitle;
+    private String title;
+    private String content;
+    private int likeCount;
+    private int commentCount;
+    private LocalDateTime createAt;
+    private Long memberId;
+    private String nickname;
+    private Boolean anonymous;
+    private String thumbnail;
+
+    public static GetPostSearchElement from(Post post) {
+        String thumbnail = findThumbnailUrl(post);
+        Boolean anonymous = post.getAnonymous();
+
+        return GetPostSearchElement.builder()
+                .boardTitle(post.getBoard().getTitle())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .likeCount(post.getLikes().size())
+                .commentCount(post.getComments().size())
+                .createAt(post.getCreatedAt())
+                .memberId(anonymous ? -1 : post.getMember().getId())
+                .nickname(anonymous ? "익명" : post.getMember().getNickname())
+                .anonymous(anonymous)
+                .thumbnail(thumbnail)
+                .build();
+    }
+
+    private static String findThumbnailUrl(Post post) {
+        List<PostImage> images = post.getImages();
+        if (images.size() >= 1)
+            return images.get(0).getImageUrl();
+        return null;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchReqDto.java
@@ -1,0 +1,17 @@
+package com.ssafy.ssafsound.domain.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+public class GetPostSearchReqDto {
+    private Long boardId;
+
+    @Size(min = 2)
+    @NotBlank
+    private String keyword;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchResDto.java
@@ -1,0 +1,22 @@
+package com.ssafy.ssafsound.domain.post.dto;
+
+import com.ssafy.ssafsound.domain.post.domain.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class GetPostSearchResDto {
+    private List<GetPostSearchElement> posts;
+
+    public static GetPostSearchResDto from(List<Post> posts) {
+        return GetPostSearchResDto.builder()
+                .posts(posts.stream()
+                        .map(GetPostSearchElement::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/exception/PostErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/exception/PostErrorInfo.java
@@ -9,7 +9,8 @@ public enum PostErrorInfo {
     DUPLICATE_REPORT("804", "이미 신고된 게시글입니다."),
     UNABLE_REPORT_MY_POST("805", "자신의 게시글은 신고할 수 없습니다."),
     UNAUTHORIZED_DELETE_POST("806", "해당 게시글 삭제 권한이 없습니다."),
-    UNAUTHORIZED_UPDATE_POST("807", "해당 게시글 수정 권한이 없습니다.");
+    UNAUTHORIZED_UPDATE_POST("807", "해당 게시글 수정 권한이 없습니다."),
+    NOT_FOUND_POSTS_SEARCH_RESULT("809", "검색 결과를 찾을 수 없습니다");
 
 
     private final String code;

--- a/src/main/java/com/ssafy/ssafsound/domain/post/exception/PostErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/exception/PostErrorInfo.java
@@ -5,13 +5,10 @@ import lombok.Getter;
 @Getter
 public enum PostErrorInfo {
     NOT_FOUND_POST("802", "게시글을 찾을 수 없습니다."),
-    NOT_FOUND_POSTS("803", "게시글 목록을 찾을 수 없습니다."),
-    DUPLICATE_REPORT("804", "이미 신고된 게시글입니다."),
-    UNABLE_REPORT_MY_POST("805", "자신의 게시글은 신고할 수 없습니다."),
-    UNAUTHORIZED_DELETE_POST("806", "해당 게시글 삭제 권한이 없습니다."),
-    UNAUTHORIZED_UPDATE_POST("807", "해당 게시글 수정 권한이 없습니다."),
-    NOT_FOUND_POSTS_SEARCH_RESULT("809", "검색 결과를 찾을 수 없습니다");
-
+    DUPLICATE_REPORT("803", "이미 신고된 게시글입니다."),
+    UNABLE_REPORT_MY_POST("804", "자신의 게시글은 신고할 수 없습니다."),
+    UNAUTHORIZED_DELETE_POST("805", "해당 게시글 삭제 권한이 없습니다."),
+    UNAUTHORIZED_UPDATE_POST("806", "해당 게시글 수정 권한이 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -30,7 +30,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM post p " +
             "JOIN FETCH p.board b " +
             "JOIN FETCH p.member " +
-            "WHERE TRIM(p.title) LIKE CONCAT('%', :keyword, '%') OR TRIM(p.content) LIKE CONCAT('%', :keyword, '%') " +
+            "WHERE (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') " +
+            "OR REPLACE(p.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) " +
             "AND b.id = :boardId ")
     List<Post> findByBoardIdAndKeywordWithDetailsFetch(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -33,5 +33,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "WHERE (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') " +
             "OR REPLACE(p.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) " +
             "AND b.id = :boardId ")
-    List<Post> findByBoardIdAndKeywordWithDetailsFetch(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
+    List<Post> findWithDetailsFetchByBoardIdAndKeyword(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -17,7 +17,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findWithDetailsByBoardId(@Param("boardId") Long boardId, Pageable pageable);
 
     boolean existsByIdAndMemberId(Long id, Long memberId);
-    
+
     @Query("SELECT p FROM post p JOIN FETCH p.member WHERE p.id = :id")
     Optional<Post> findByIdWithMember(@Param("id") Long id);
 
@@ -27,4 +27,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @EntityGraph(attributePaths = {"board", "member"})
     List<Post> findWithDetailsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
+    @Query("SELECT p FROM post p " +
+            "JOIN FETCH p.board b " +
+            "JOIN FETCH p.member " +
+            "WHERE TRIM(p.title) LIKE CONCAT('%', :keyword, '%') OR TRIM(p.content) LIKE CONCAT('%', :keyword, '%') " +
+            "AND b.id = :boardId ")
+    List<Post> findByBoardIdAndKeywordWithDetailsFetch(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -58,10 +58,6 @@ public class PostService {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         List<Post> posts = postRepository.findWithDetailsByBoardId(boardId, pageRequest);
 
-        if (posts.size() == 0) {
-            throw new PostException(PostErrorInfo.NOT_FOUND_POSTS);
-        }
-
         return GetPostResDto.from(posts);
     }
 
@@ -277,9 +273,6 @@ public class PostService {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetch(pageRequest);
 
-        if (hotPosts.size() == 0) {
-            throw new PostException(PostErrorInfo.NOT_FOUND_POSTS);
-        }
         return GetPostHotResDto.from(hotPosts);
     }
 
@@ -287,10 +280,6 @@ public class PostService {
     public GetPostMyResDto findMyPosts(Pageable pageable, Long memberId) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         List<Post> posts = postRepository.findWithDetailsByMemberId(memberId, pageRequest);
-
-        if (posts.size() == 0) {
-            throw new PostException(PostErrorInfo.NOT_FOUND_POSTS);
-        }
 
         return GetPostMyResDto.from(posts);
     }
@@ -303,10 +292,6 @@ public class PostService {
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         List<Post> posts = postRepository.findByBoardIdAndKeywordWithDetailsFetch(boardId, removeSpace(keyword), pageRequest);
-
-        if (posts.size() == 0) {
-            throw new PostException(PostErrorInfo.NOT_FOUND_POSTS_SEARCH_RESULT);
-        }
 
         return GetPostSearchResDto.from(posts);
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -291,12 +291,8 @@ public class PostService {
         }
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<Post> posts = postRepository.findWithDetailsFetchByBoardIdAndKeyword(boardId, removeSpace(keyword), pageRequest);
+        List<Post> posts = postRepository.findWithDetailsFetchByBoardIdAndKeyword(boardId, keyword.replaceAll(" ", ""), pageRequest);
 
         return GetPostSearchResDto.from(posts);
-    }
-
-    private String removeSpace(String keyword) {
-        return keyword.replaceAll(" ", "");
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -291,7 +291,7 @@ public class PostService {
         }
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<Post> posts = postRepository.findByBoardIdAndKeywordWithDetailsFetch(boardId, removeSpace(keyword), pageRequest);
+        List<Post> posts = postRepository.findWithDetailsFetchByBoardIdAndKeyword(boardId, removeSpace(keyword), pageRequest);
 
         return GetPostSearchResDto.from(posts);
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -51,13 +51,13 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public GetPostResDto findPosts(Long boardId, Pageable pageable) {
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-
         if (!boardRepository.existsById(boardId)) {
             throw new BoardException(BoardErrorInfo.NO_BOARD);
         }
 
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         List<Post> posts = postRepository.findWithDetailsByBoardId(boardId, pageRequest);
+
         if (posts.size() == 0) {
             throw new PostException(PostErrorInfo.NOT_FOUND_POSTS);
         }
@@ -293,5 +293,21 @@ public class PostService {
         }
 
         return GetPostMyResDto.from(posts);
+    }
+
+    @Transactional(readOnly = true)
+    public GetPostSearchResDto searchPosts(Long boardId, String keyword, Pageable pageable) {
+        if (!boardRepository.existsById(boardId)) {
+            throw new BoardException(BoardErrorInfo.NO_BOARD);
+        }
+
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        List<Post> posts = postRepository.findByBoardIdAndKeywordWithDetailsFetch(boardId, keyword, pageRequest);
+
+        if (posts.size() == 0) {
+            throw new PostException(PostErrorInfo.NOT_FOUND_POSTS_SEARCH_RESULT);
+        }
+
+        return GetPostSearchResDto.from(posts);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -302,12 +302,16 @@ public class PostService {
         }
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<Post> posts = postRepository.findByBoardIdAndKeywordWithDetailsFetch(boardId, keyword, pageRequest);
+        List<Post> posts = postRepository.findByBoardIdAndKeywordWithDetailsFetch(boardId, removeSpace(keyword), pageRequest);
 
         if (posts.size() == 0) {
             throw new PostException(PostErrorInfo.NOT_FOUND_POSTS_SEARCH_RESULT);
         }
 
         return GetPostSearchResDto.from(posts);
+    }
+
+    private String removeSpace(String keyword) {
+        return keyword.replaceAll(" ", "");
     }
 }


### PR DESCRIPTION
## Issues

- #123 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 게시글 검색 기능 구현
- 게시글 keyword 검증(한글자 or 공백만 있으면 검색 안됨)

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->
게시글 검색은 현재 와일드 카드기반 like 검색을 수행합니다.
공백 포함없이 키워드가 들어가는 게시글을 다 검색합니다!

```
@Query("SELECT p FROM post p " +
            "JOIN FETCH p.board b " +
            "JOIN FETCH p.member " +
            "WHERE (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') " +
            "OR REPLACE(p.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) " +
            "AND b.id = :boardId ")
    List<Post> findWithDetailsFetchByBoardIdAndKeyword(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
```
게시글 검색 관련 쿼리문입니다. 피드백 적극 환경합니다.

## 기타
차후 성능 최적화가 필요하다면, Elasticsearch를 고려해볼 수 있을거 같습니다!

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
