### PR TITLE
feat: member input portfolio

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -47,10 +47,10 @@ public class MemberController {
                 .build();
     }
 
-    @PutMapping("/profile")
-    public EnvelopeResponse registerMemberProfile(@Authentication AuthenticatedMember authenticatedMember,
+    @PutMapping("/portfolio")
+    public EnvelopeResponse registerMemberPortfolio(@Authentication AuthenticatedMember authenticatedMember,
                                                  @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
-        memberService.registerMemberProfile(authenticatedMember, putMemberProfileReqDto);
+        memberService.registerMemberPortfolio(authenticatedMember, putMemberProfileReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -41,9 +41,16 @@ public class MemberController {
 
     @PostMapping("/ssafy-certification")
     public EnvelopeResponse<PostCertificationInfoResDto> certifySSAFYInformation(@Authentication AuthenticatedMember authenticatedMember,
-                                                       @Valid @RequestBody PostCertificationInfoReqDto postCertificationInfoReqDto) {
+                                                                                @Valid @RequestBody PostCertificationInfoReqDto postCertificationInfoReqDto) {
         return EnvelopeResponse.<PostCertificationInfoResDto>builder()
                 .data(memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto))
+                .build();
+    }
+
+    @PutMapping("/profile")
+    public EnvelopeResponse registerMemberProfile(@Authentication AuthenticatedMember authenticatedMember,
+                                                 @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
+        return EnvelopeResponse.builder()
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -50,6 +50,7 @@ public class MemberController {
     @PutMapping("/profile")
     public EnvelopeResponse registerMemberProfile(@Authentication AuthenticatedMember authenticatedMember,
                                                  @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
+        memberService.registerMemberProfile(authenticatedMember, putMemberProfileReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -2,7 +2,7 @@ package com.ssafy.ssafsound.domain.member.domain;
 
 import com.ssafy.ssafsound.domain.BaseTimeEntity;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberInfoReqDto;
-import com.ssafy.ssafsound.domain.member.dto.PutMemberProfileReqDto;
+import com.ssafy.ssafsound.domain.member.dto.PutMemberLink;
 import com.ssafy.ssafsound.domain.meta.converter.CampusConverter;
 import com.ssafy.ssafsound.domain.meta.converter.MajorTrackConverter;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity(name="member")
@@ -105,24 +106,22 @@ public class Member extends BaseTimeEntity {
         this.campus = consumer.getMetaData(MetaDataType.CAMPUS.name(), postMemberInfoReqDto.getCampus());
     }
 
-    public void setMemberLinks(PutMemberProfileReqDto putMemberProfileReqDto) {
-        putMemberProfileReqDto.getMemberLinks().forEach(memberLinks -> {
-            MemberLink memberLink = MemberLink.builder()
+    public void setMemberLinks(List<PutMemberLink> memberLinks) {
+        memberLinks.forEach(memberLink -> {
+            this.memberLinks.add(MemberLink.builder()
                     .member(this)
-                    .linkName(memberLinks.getLinkName())
-                    .path(memberLinks.getPath())
-                    .build();
-            this.memberLinks.add(memberLink);
+                    .linkName(memberLink.getLinkName())
+                    .path(memberLink.getPath())
+                    .build());
         });
     }
 
-    public void setMemberSkills(PutMemberProfileReqDto putMemberProfileReqDto, MetaDataConsumer consumer) {
-        putMemberProfileReqDto.getSkills().forEach(memberSkills -> {
-            MemberSkill memberSkill = MemberSkill.builder()
+    public void setMemberSkills(List<String> memberSkills, MetaDataConsumer consumer) {
+        memberSkills.forEach(memberSkill -> {
+            this.memberSkills.add(MemberSkill.builder()
                     .member(this)
-                    .skill(consumer.getMetaData(MetaDataType.SKILL.name(), memberSkills))
-                    .build();
-            this.memberSkills.add(memberSkill);
+                    .skill(consumer.getMetaData(MetaDataType.SKILL.name(), memberSkill))
+                    .build());
         });
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafsound.domain.member.domain;
 
 import com.ssafy.ssafsound.domain.BaseTimeEntity;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberInfoReqDto;
+import com.ssafy.ssafsound.domain.member.dto.PutMemberProfileReqDto;
 import com.ssafy.ssafsound.domain.meta.converter.CampusConverter;
 import com.ssafy.ssafsound.domain.meta.converter.MajorTrackConverter;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
@@ -14,6 +15,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity(name="member")
 @Table(indexes = @Index(name = "nickname_index", columnList = "nickname", unique = true))
@@ -73,6 +76,10 @@ public class Member extends BaseTimeEntity {
     @Column
     private Boolean publicPortfolio;
 
+    @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @Builder.Default
+    private Set<MemberLink> memberLinks = new HashSet<>();
+
     @PreUpdate
     public void preUpdateCertificationTryTime() {
         this.certificationTryTime = LocalDateTime.now();
@@ -92,6 +99,17 @@ public class Member extends BaseTimeEntity {
         this.semester = postMemberInfoReqDto.getSemester();
         this.major = postMemberInfoReqDto.getIsMajor();
         this.campus = consumer.getMetaData(MetaDataType.CAMPUS.name(), postMemberInfoReqDto.getCampus());
+    }
+
+    public void setMemberLinks(PutMemberProfileReqDto putMemberProfileReqDto) {
+        putMemberProfileReqDto.getMemberLinks().forEach(memberLinks -> {
+            MemberLink memberLink = MemberLink.builder()
+                    .member(this)
+                    .linkName(memberLinks.getLinkName())
+                    .path(memberLinks.getPath())
+                    .build();
+            this.memberLinks.add(memberLink);
+        });
     }
 
     public void setMajorTrack(MetaData majorTrack) {

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -80,6 +80,10 @@ public class Member extends BaseTimeEntity {
     @Builder.Default
     private Set<MemberLink> memberLinks = new HashSet<>();
 
+    @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @Builder.Default
+    private Set<MemberSkill> memberSkills = new HashSet<>();
+
     @PreUpdate
     public void preUpdateCertificationTryTime() {
         this.certificationTryTime = LocalDateTime.now();
@@ -109,6 +113,16 @@ public class Member extends BaseTimeEntity {
                     .path(memberLinks.getPath())
                     .build();
             this.memberLinks.add(memberLink);
+        });
+    }
+
+    public void setMemberSkills(PutMemberProfileReqDto putMemberProfileReqDto, MetaDataConsumer consumer) {
+        putMemberProfileReqDto.getSkills().forEach(memberSkills -> {
+            MemberSkill memberSkill = MemberSkill.builder()
+                    .member(this)
+                    .skill(consumer.getMetaData(MetaDataType.SKILL.name(), memberSkills))
+                    .build();
+            this.memberSkills.add(memberSkill);
         });
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberLink.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberLink.java
@@ -19,6 +19,9 @@ public class MemberLink {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "link_name")
+    private String linkName;
+
     @Column
     private String path;
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberProfile.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberProfile.java
@@ -1,6 +1,5 @@
 package com.ssafy.ssafsound.domain.member.domain;
 
-import com.ssafy.ssafsound.domain.member.dto.PutMemberProfileReqDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +26,7 @@ public class MemberProfile {
     @JoinColumn(name="member_id")
     private Member member;
 
-    public void changeIntroduceMyself(PutMemberProfileReqDto putMemberProfileReqDto) {
-        this.introduce = putMemberProfileReqDto.getIntroduceMyself();
+    public void changeIntroduceMyself(String introduceMyself) {
+        this.introduce = introduceMyself;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberProfile.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberProfile.java
@@ -1,5 +1,6 @@
 package com.ssafy.ssafsound.domain.member.domain;
 
+import com.ssafy.ssafsound.domain.member.dto.PutMemberProfileReqDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,4 +26,8 @@ public class MemberProfile {
     @MapsId
     @JoinColumn(name="member_id")
     private Member member;
+
+    public void changeIntroduceMyself(PutMemberProfileReqDto putMemberProfileReqDto) {
+        this.introduce = putMemberProfileReqDto.getIntroduceMyself();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberLink.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberLink.java
@@ -1,0 +1,21 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PostMemberLink {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String url;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberLink.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberLink.java
@@ -11,11 +11,11 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class PostMemberLink {
+public class PutMemberLink {
 
     @NotBlank
-    private String name;
+    private String linkName;
 
     @NotBlank
-    private String url;
+    private String path;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
@@ -7,8 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotBlank;
 import java.util.List;
 
 @Builder
@@ -16,8 +14,6 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 public class PutMemberProfileReqDto {
-
-    @NotBlank
     private String introduceMyself;
 
     @CheckSkills

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
@@ -21,5 +21,5 @@ public class PutMemberProfileReqDto {
     @CheckSkills
     private List<String> skills;
 
-    private List<PostMemberLink> postMemberLinks;
+    private List<PutMemberLink> memberLinks;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
@@ -1,5 +1,7 @@
 package com.ssafy.ssafsound.domain.member.dto;
 
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.domain.MemberProfile;
 import com.ssafy.ssafsound.domain.meta.validator.CheckSkills;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,4 +24,11 @@ public class PutMemberProfileReqDto {
     private List<String> skills;
 
     private List<PutMemberLink> memberLinks;
+
+    public MemberProfile toMemberProfile(Member member) {
+        return MemberProfile.builder()
+                .member(member)
+                .introduce(this.getIntroduceMyself())
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberProfileReqDto.java
@@ -1,0 +1,25 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import com.ssafy.ssafsound.domain.meta.validator.CheckSkills;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PutMemberProfileReqDto {
+
+    @NotBlank
+    private String introduceMyself;
+
+    @CheckSkills
+    private List<String> skills;
+
+    private List<PostMemberLink> postMemberLinks;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
@@ -1,7 +1,0 @@
-package com.ssafy.ssafsound.domain.member.repository;
-
-import com.ssafy.ssafsound.domain.member.domain.MemberLink;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MemberLinkRepository extends JpaRepository<MemberLink, Long> {
-}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
@@ -3,7 +3,13 @@ package com.ssafy.ssafsound.domain.member.repository;
 import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberLink;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberLinkRepository extends JpaRepository<MemberLink, Long> {
-    void deleteMemberLinksByMember(Member member);
+
+    @Modifying
+    @Query("DELETE FROM  member_link ml WHERE ml.member = :member")
+    void deleteMemberLinksByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafsound.domain.member.repository;
+
+import com.ssafy.ssafsound.domain.member.domain.MemberLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberLinkRepository extends JpaRepository<MemberLink, Long> {
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberLinkRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.member.repository;
+
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.domain.MemberLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberLinkRepository extends JpaRepository<MemberLink, Long> {
+    void deleteMemberLinksByMember(Member member);
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberProfileRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberProfileRepository.java
@@ -1,7 +1,11 @@
 package com.ssafy.ssafsound.domain.member.repository;
 
+import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
+    Optional<MemberProfile> findMemberProfileByMember(Member member);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberProfileRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberProfileRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafsound.domain.member.repository;
+
+import com.ssafy.ssafsound.domain.member.domain.MemberProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
@@ -3,7 +3,13 @@ package com.ssafy.ssafsound.domain.member.repository;
 import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.domain.MemberSkill;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
-    void deleteMemberSkillsByMember(Member member);
+
+    @Modifying
+    @Query("DELETE FROM  member_skill ms WHERE ms.member = :member")
+    void deleteMemberSkillsByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafsound.domain.member.repository;
+
+import com.ssafy.ssafsound.domain.member.domain.MemberSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.member.repository;
+
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.domain.MemberSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
+    void deleteMemberSkillsByMember(Member member);
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberSkillRepository.java
@@ -1,7 +1,0 @@
-package com.ssafy.ssafsound.domain.member.repository;
-
-import com.ssafy.ssafsound.domain.member.domain.MemberSkill;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
-}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -25,9 +25,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberRoleRepository memberRoleRepository;
     private final MemberTokenRepository memberTokenRepository;
-    private final MemberLinkRepository memberLinkRepository;
     private final MemberProfileRepository memberProfileRepository;
-    private final MemberSkillRepository memberSkillRepository;
     private final MetaDataConsumer metaDataConsumer;
     @Value("${spring.constant.certification.CERTIFICATION_INQUIRY_TIME}")
     private Integer MAX_CERTIFICATION_INQUIRY_COUNT;
@@ -106,8 +104,9 @@ public class MemberService {
 
     @Transactional
     public void registerMemberProfile(AuthenticatedMember authenticatedMember, PutMemberProfileReqDto putMemberProfileReqDto) {
-        Member member = memberRepository.getReferenceById(authenticatedMember.getMemberId());
+        Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
+        member.setMemberLinks(putMemberProfileReqDto);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -106,9 +106,9 @@ public class MemberService {
     }
 
     @Transactional
-    public void registerMemberProfile(AuthenticatedMember authenticatedMember, PutMemberProfileReqDto putMemberProfileReqDto) {
+    public void registerMemberPortfolio(AuthenticatedMember authenticatedMember, PutMemberProfileReqDto putMemberProfileReqDto) {
         Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
-        setMemberProfileIntroduceByMember(member, putMemberProfileReqDto);
+        setMemberPortfolioIntroduceByMember(member, putMemberProfileReqDto);
         deleteExistMemberLinksAllByMemberAndSaveNewRequest(member, putMemberProfileReqDto.getMemberLinks());
         deleteExistMemberSkillsAllByMemberAndSaveNewRequest(member, putMemberProfileReqDto.getSkills());
     }
@@ -122,7 +122,7 @@ public class MemberService {
         memberSkillRepository.deleteMemberSkillsByMember(member);
         member.setMemberSkills(memberSkills, metaDataConsumer);
     }
-    public void setMemberProfileIntroduceByMember(Member member, PutMemberProfileReqDto putMemberProfileReqDto) {
+    public void setMemberPortfolioIntroduceByMember(Member member, PutMemberProfileReqDto putMemberProfileReqDto) {
         if (putMemberProfileReqDto.getIntroduceMyself() != null) {
             memberProfileRepository.findMemberProfileByMember(member).ifPresentOrElse(
                     memberProfile -> memberProfile.changeIntroduceMyself(putMemberProfileReqDto.getIntroduceMyself()),

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -5,9 +5,7 @@ import com.ssafy.ssafsound.domain.member.domain.*;
 import com.ssafy.ssafsound.domain.member.dto.*;
 import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
-import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
-import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
-import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
+import com.ssafy.ssafsound.domain.member.repository.*;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
@@ -27,6 +25,9 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberRoleRepository memberRoleRepository;
     private final MemberTokenRepository memberTokenRepository;
+    private final MemberLinkRepository memberLinkRepository;
+    private final MemberProfileRepository memberProfileRepository;
+    private final MemberSkillRepository memberSkillRepository;
     private final MetaDataConsumer metaDataConsumer;
     @Value("${spring.constant.certification.CERTIFICATION_INQUIRY_TIME}")
     private Integer MAX_CERTIFICATION_INQUIRY_COUNT;
@@ -101,6 +102,12 @@ public class MemberService {
             member.increaseCertificationInquiryCount();
             return PostCertificationInfoResDto.of(false, member.getCertificationInquiryCount());
         }
+    }
+
+    @Transactional
+    public void registerMemberProfile(AuthenticatedMember authenticatedMember, PutMemberProfileReqDto putMemberProfileReqDto) {
+        Member member = memberRepository.getReferenceById(authenticatedMember.getMemberId());
+
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -107,6 +107,7 @@ public class MemberService {
         Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
         member.setMemberLinks(putMemberProfileReqDto);
+        member.setMemberSkills(putMemberProfileReqDto, metaDataConsumer);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -105,9 +105,14 @@ public class MemberService {
     @Transactional
     public void registerMemberProfile(AuthenticatedMember authenticatedMember, PutMemberProfileReqDto putMemberProfileReqDto) {
         Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+        MemberProfile memberProfile = MemberProfile.builder()
+                .member(member)
+                .introduce(putMemberProfileReqDto.getIntroduceMyself())
+                .build();
 
         member.setMemberLinks(putMemberProfileReqDto);
         member.setMemberSkills(putMemberProfileReqDto, metaDataConsumer);
+        memberProfileRepository.save(memberProfile);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Issues

- #133 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 멤버는 자신의 프로필에 대한 자기소개서를 작성할 수 있습니다.
- 멤버는 자신의 기술 스택에 대해 작성할 수 있습니다.
- 멤버는 자신의 소개 링크에 대해 작성할 수 있습니다.

MemberSkill과 MemberLink는 양방향 Mapping을 가지고 있습니다.
만약, Member가 삭제된다면 MemberSkill과 MemberLink도 함께 삭제될 수 있도록
```Java
orphanRemoval = true
```
를 지정했습니다.

***헷갈릴 수 있는 비즈니스 로직***
Http Method Put을 통해 해당 API를 호출합니다.
따라서, 변경 사항이 있을 경우 때문에 MemberProfile 같은 경우는 1:1 Mapping이기 때문에 이미 존재한다면 수정
MemberSkills과 MemberLink의 경우는 이미 존재한다면, 모두 삭제하고 새롭게 데이터베이스에 저장합니다.

* CGLIB PROXY 객체를 생성하는 부분에 있어서 오해
이미 알고 있던 내용이라면 넘어가셔도 되지만 제가 잘못 이해하고 있던 부분을 공유 해드리고, 도움이 된다면 좋을 것 같아요!

@Transactional 애노테이션이 하나라도 붙어있는 클래스가 존재한다면 Spring에서 Application을 실행할때, 해당 클래스를 Proxy 객체로 생성하여 빈으로 등록합니다.

만약 @Transactional 애노테이션이 하나라도 붙어있지 않다면 실제 객체를 생성하여 빈으로 등록합니다.

---

마주쳤던 이슈 상황 
```Java
package com.ssafy.ssafsound.domain.member.repository;

import com.ssafy.ssafsound.domain.member.domain.Member;
import com.ssafy.ssafsound.domain.member.domain.MemberSkill;
import org.springframework.data.jpa.repository.JpaRepository;

public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
    void deleteMemberSkillsByMember(Member member);
}
```
트랜잭션 애노테이션이 붙은 메서드에서 해당 deleteMemberSkillsByMember를 트랜잭션 애노테이션이 붙은 메서드로 분리하여 호출했는데 삭제 쿼리가 발생하지 않는 문제를 직면했습니다.

그 이유는 프록시 객체인 Service가 실제 메서드를 실행하기전 프록시 객체에서 Transactional을 생성하고, 실제 객체를 통해 해당 메서드를 수행하기 때문에 수행 과정에서 Transactional 애노테이션이 붙어있는 메서드의 트랜잭션을 생성하지 않기 떄문이었습니다.
<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
