### PR TITLE
test : 점심 메뉴 테스트 및 리팩토링

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/controller/LunchController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/controller/LunchController.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListReqDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchResDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListResDto;
 import com.ssafy.ssafsound.domain.lunch.dto.PostLunchPollResDto;
+import com.ssafy.ssafsound.domain.lunch.service.LunchPollService;
 import com.ssafy.ssafsound.domain.lunch.service.LunchService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import javax.validation.Valid;
 public class LunchController {
 
     private final LunchService lunchService;
+    private final LunchPollService lunchPollService;
 
     @GetMapping("/{lunchId}")
     public EnvelopeResponse<GetLunchResDto> getLunchByLunchId(@PathVariable @NumberFormat Long lunchId){
@@ -41,7 +43,7 @@ public class LunchController {
     public EnvelopeResponse<PostLunchPollResDto> postLunchPoll(@Authentication AuthenticatedMember user, @PathVariable @NumberFormat Long lunchId){
 
         return EnvelopeResponse.<PostLunchPollResDto>builder()
-                .data(lunchService.saveLunchPoll(user.getMemberId(), lunchId))
+                .data(lunchPollService.saveLunchPoll(user.getMemberId(), lunchId))
                 .build();
     }
 
@@ -49,7 +51,7 @@ public class LunchController {
     public EnvelopeResponse<PostLunchPollResDto> revertLunchPoll(@Authentication AuthenticatedMember user, @PathVariable @NumberFormat Long lunchId){
 
         return EnvelopeResponse.<PostLunchPollResDto>builder()
-                .data(lunchService.deleteLunchPoll(user.getMemberId(), lunchId))
+                .data(lunchPollService.deleteLunchPoll(user.getMemberId(), lunchId))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/domain/LunchPoll.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/domain/LunchPoll.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class LunchPoll {
 
     @Id
@@ -32,15 +33,6 @@ public class LunchPoll {
 
     @Column
     private LocalDate polledAt;
-
-    @Builder
-    public LunchPoll(Lunch lunch, Member member, LocalDate polledAt) {
-        this.lunch = lunch;
-        this.member = member;
-        this.polledAt = polledAt;
-
-        lunch.getLunchPolls().add(this);
-    }
 
     public void setLunch(Lunch lunch){
 

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/domain/LunchPoll.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/domain/LunchPoll.java
@@ -51,4 +51,10 @@ public class LunchPoll {
         this.lunch = lunch;
         lunch.getLunchPolls().add(this);
     }
+
+    public void deleteLunchPoll() {
+        if (this.lunch != null) {
+            this.lunch.getLunchPolls().remove(this);
+        }
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/dto/GetLunchListReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/dto/GetLunchListReqDto.java
@@ -1,5 +1,6 @@
 package com.ssafy.ssafsound.domain.lunch.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
+@Builder
 public class GetLunchListReqDto {
 
     @NotBlank

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/repository/LunchPollRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/repository/LunchPollRepository.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafsound.domain.lunch.repository;
 
 import com.ssafy.ssafsound.domain.lunch.domain.Lunch;
 import com.ssafy.ssafsound.domain.lunch.domain.LunchPoll;
+import com.ssafy.ssafsound.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,11 +14,7 @@ import java.util.Optional;
 @Repository
 public interface LunchPollRepository extends JpaRepository<LunchPoll, Long> {
 
-    LunchPoll findByMember_IdAndPolledAt(Long memberId, LocalDate polledAt);
+    LunchPoll findByMemberAndPolledAt(Member member, LocalDate polledAt);
 
-    @Modifying
-    @Query(value = "insert into lunch_poll (lunch_id,member_id,polled_at) values(:lunchId, :memberId, :polledAt)", nativeQuery = true)
-    void saveByMember_IdAndLunch_Id(Long memberId, Long lunchId, LocalDate polledAt);
-
-    Optional<LunchPoll> findByMember_IdAndLunch(Long memberId, Lunch lunch);
+    Optional<LunchPoll> findByMemberAndLunch(Member member, Lunch lunch);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchPollService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchPollService.java
@@ -1,0 +1,84 @@
+package com.ssafy.ssafsound.domain.lunch.service;
+
+import com.ssafy.ssafsound.domain.lunch.domain.Lunch;
+import com.ssafy.ssafsound.domain.lunch.domain.LunchPoll;
+import com.ssafy.ssafsound.domain.lunch.dto.PostLunchPollResDto;
+import com.ssafy.ssafsound.domain.lunch.exception.LunchErrorInfo;
+import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
+import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
+import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class LunchPollService {
+
+    private final LunchRepository lunchRepository;
+
+    private final LunchPollRepository lunchPollRepository;
+
+    private final Clock clock;
+
+    @Transactional
+    public PostLunchPollResDto saveLunchPoll(Long memberId, Long lunchId) {
+
+        LocalDate currentTime = LocalDate.now(clock);
+
+        // 1. 점심 메뉴 존재 여부 확인
+        Lunch lunch = lunchRepository.findById(lunchId)
+                .orElseThrow(()-> new LunchException(LunchErrorInfo.INVALID_LUNCH_ID));
+
+        // 2. 점심 메뉴가 당일 메뉴인지 확인
+        if (!lunch.getCreatedAt().isEqual(currentTime)) {
+            throw new LunchException(LunchErrorInfo.INVALID_DATE);
+        }
+
+        // 3. 오늘 투표한 점심 투표 엔티티 조회
+        LunchPoll lunchPoll = lunchPollRepository.findByMember_IdAndPolledAt(memberId, currentTime);
+
+        // 4-1. 이미 오늘 투표한 경우
+        if (lunchPoll != null) {
+            // 5-1. 중복 투표인 경우
+            if (lunchPoll.getLunch().equals(lunch)) {
+                throw new LunchException(LunchErrorInfo.DUPLICATE_LUNCH_POLL);
+            }
+
+            // 5-2. 투표 선택지가 바뀐 경우
+            lunchPoll.setLunch(lunch);
+        }
+
+        // 4-2. 오늘 첫 투표인 경우
+        else lunchPollRepository.saveByMember_IdAndLunch_Id(memberId, lunchId, currentTime);
+
+        return PostLunchPollResDto.of((long) lunch.getLunchPolls().size());
+    }
+
+    @Transactional
+    public PostLunchPollResDto deleteLunchPoll(Long memberId, Long lunchId) {
+
+        LocalDate currentTime = LocalDate.now(clock);
+
+        // Lunch 엔티티 조회 후 validate
+        Lunch lunch = lunchRepository.findById(lunchId)
+                .orElseThrow(() -> new LunchException((LunchErrorInfo.INVALID_LUNCH_ID)));
+
+        // 멤버 id와 Lunch 엔티티 기반으로 LunchPoll 엔티티 조회 후 validate
+        LunchPoll lunchPoll = lunchPollRepository.findByMember_IdAndLunch(memberId, lunch)
+                .orElseThrow(() -> new LunchException(LunchErrorInfo.NO_LUNCH_POLL));
+
+        if (!lunchPoll.getPolledAt().isEqual(currentTime)) {
+            throw new LunchException(LunchErrorInfo.INVALID_DATE);
+        }
+
+        // 투표 삭제
+        lunchPollRepository.delete(lunchPoll);
+
+        // 변화한 투표 수 리턴
+        return PostLunchPollResDto.of((long) lunch.getLunchPolls().size());
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchPollService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchPollService.java
@@ -7,6 +7,10 @@ import com.ssafy.ssafsound.domain.lunch.exception.LunchErrorInfo;
 import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.member.exception.MemberException;
+import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +26,8 @@ public class LunchPollService {
 
     private final LunchPollRepository lunchPollRepository;
 
+    private final MemberRepository memberRepository;
+
     private final Clock clock;
 
     @Transactional
@@ -33,13 +39,17 @@ public class LunchPollService {
         Lunch lunch = lunchRepository.findById(lunchId)
                 .orElseThrow(()-> new LunchException(LunchErrorInfo.INVALID_LUNCH_ID));
 
+        // Member 엔티티 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
         // 2. 점심 메뉴가 당일 메뉴인지 확인
         if (!lunch.getCreatedAt().isEqual(currentTime)) {
             throw new LunchException(LunchErrorInfo.INVALID_DATE);
         }
 
         // 3. 오늘 투표한 점심 투표 엔티티 조회
-        LunchPoll lunchPoll = lunchPollRepository.findByMember_IdAndPolledAt(memberId, currentTime);
+        LunchPoll lunchPoll = lunchPollRepository.findByMemberAndPolledAt(member, currentTime);
 
         // 4-1. 이미 오늘 투표한 경우
         if (lunchPoll != null) {
@@ -50,10 +60,17 @@ public class LunchPollService {
 
             // 5-2. 투표 선택지가 바뀐 경우
             lunchPoll.setLunch(lunch);
-        }
 
-        // 4-2. 오늘 첫 투표인 경우
-        else lunchPollRepository.saveByMember_IdAndLunch_Id(memberId, lunchId, currentTime);
+        } else {
+            // 4-2. 오늘 첫 투표인 경우
+            lunchPoll = LunchPoll.builder()
+                    .member(member)
+                    .lunch(lunch)
+                    .polledAt(currentTime)
+                    .build();
+
+            lunchPollRepository.save(lunchPoll);
+        }
 
         return PostLunchPollResDto.of((long) lunch.getLunchPolls().size());
     }
@@ -67,15 +84,20 @@ public class LunchPollService {
         Lunch lunch = lunchRepository.findById(lunchId)
                 .orElseThrow(() -> new LunchException((LunchErrorInfo.INVALID_LUNCH_ID)));
 
-        // 멤버 id와 Lunch 엔티티 기반으로 LunchPoll 엔티티 조회 후 validate
-        LunchPoll lunchPoll = lunchPollRepository.findByMember_IdAndLunch(memberId, lunch)
-                .orElseThrow(() -> new LunchException(LunchErrorInfo.NO_LUNCH_POLL));
-
-        if (!lunchPoll.getPolledAt().isEqual(currentTime)) {
+        if (!lunch.getCreatedAt().isEqual(currentTime)) {
             throw new LunchException(LunchErrorInfo.INVALID_DATE);
         }
 
+        // Member 엔티티 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        // 멤버 id와 Lunch 엔티티 기반으로 LunchPoll 엔티티 조회 후 validate
+        LunchPoll lunchPoll = lunchPollRepository.findByMemberAndLunch(member, lunch)
+                .orElseThrow(() -> new LunchException(LunchErrorInfo.NO_LUNCH_POLL));
+
         // 투표 삭제
+        lunchPoll.deleteLunchPoll();
         lunchPollRepository.delete(lunchPoll);
 
         // 변화한 투표 수 리턴

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
@@ -54,12 +54,13 @@ public class LunchService {
         }
 
         // 투표한 점심 메뉴 찾기
-        Lunch polledLunch = lunchPollRepository.findByMember_IdAndPolledAt(memberId, LocalDate.now()).getLunch();
+        LunchPoll lunchPoll = lunchPollRepository.findByMember_IdAndPolledAt(memberId, LocalDate.now());
+        Long polledAt = lunchPoll != null ? (long) lunches.indexOf(lunchPoll.getLunch()) : -1L;
 
         // 인증 유저 응답
         return GetLunchListResDto.of(lunches.stream()
                 .map(lunch -> GetLunchListElementResDto.of(lunch, (long)lunch.getLunchPolls().size()))
-                .collect(Collectors.toList()), (long) lunches.indexOf(polledLunch));
+                .collect(Collectors.toList()), polledAt);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
@@ -10,7 +10,6 @@ import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +25,6 @@ public class LunchService {
 
     private final LunchPollRepository lunchPollRepository;
 
-    @Qualifier("EnumMetaDataConsumer")
     private final MetaDataConsumer metaDataConsumer;
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/lunch/service/LunchService.java
@@ -7,6 +7,10 @@ import com.ssafy.ssafsound.domain.lunch.exception.LunchErrorInfo;
 import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.member.exception.MemberException;
+import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +29,8 @@ public class LunchService {
     private final LunchRepository lunchRepository;
 
     private final LunchPollRepository lunchPollRepository;
+
+    private final MemberRepository memberRepository;
 
     private final MetaDataConsumer metaDataConsumer;
 
@@ -59,7 +65,10 @@ public class LunchService {
         }
 
         // 투표한 점심 메뉴 찾기
-        LunchPoll lunchPoll = lunchPollRepository.findByMember_IdAndPolledAt(memberId, currentTime);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        LunchPoll lunchPoll = lunchPollRepository.findByMemberAndPolledAt(member, currentTime);
         Long polledAt = lunchPoll != null ? (long) lunches.indexOf(lunchPoll.getLunch()) : -1L;
 
         // 인증 유저 응답

--- a/src/main/java/com/ssafy/ssafsound/global/config/TimeConfig.java
+++ b/src/main/java/com/ssafy/ssafsound/global/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafsound.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,3 @@
 spring:
   profiles:
     active: local
-
-logging:
-  level:
-    com:
-      amazonaws:
-        util:
-          EC2MetadataUtils: error

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchPollServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchPollServiceTest.java
@@ -1,0 +1,250 @@
+package com.ssafy.ssafsound.domain.lunch.service;
+
+import com.ssafy.ssafsound.domain.lunch.domain.Lunch;
+import com.ssafy.ssafsound.domain.lunch.domain.LunchPoll;
+import com.ssafy.ssafsound.domain.lunch.dto.PostLunchPollResDto;
+import com.ssafy.ssafsound.domain.lunch.exception.LunchErrorInfo;
+import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
+import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
+import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.member.exception.MemberException;
+import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LunchPollServiceTest {
+
+    @Mock
+    private LunchRepository lunchRepository;
+
+    @Mock
+    private LunchPollRepository lunchPollRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private LunchPollService lunchPollService;
+
+    private Lunch lunch1;
+    private Lunch lunch2;
+    private Lunch lunch3;
+
+    private Member member1;
+    private Member member2;
+
+    private LunchPoll lunchPoll;
+
+    private String testLocalDateTime = "2023-07-10T10:15:00Z";
+    private String testLocalDate = "2023-07-10";
+    private LocalDate today = LocalDate.parse(testLocalDate);
+
+    @BeforeEach
+    void setUp() {
+
+        lunch1 = Lunch.builder()
+                .id(1L)
+                .createdAt(today)
+                .build();
+
+        lunch2 = Lunch.builder()
+                .id(2L)
+                .createdAt(today)
+                .build();
+
+        lunch3 = Lunch.builder()
+                .id(3L)
+                .createdAt(today.plusDays(1))
+                .build();
+
+        member1 = Member.builder()
+                .id(1L)
+                .build();
+
+        member2 = Member.builder()
+                .id(2L)
+                .build();
+
+        lunchPoll = LunchPoll.builder()
+                .lunch(lunch2)
+                .member(member1)
+                .polledAt(today)
+                .build();
+
+        // Clock mocking
+        given(clock.instant()).willReturn(Instant.parse(testLocalDateTime));
+        given(clock.getZone()).willReturn(ZoneId.of("Asia/Seoul"));
+
+        lenient().when(lunchRepository.findById(1L)).thenReturn(Optional.of(lunch1));
+        lenient().when(lunchRepository.findById(2L)).thenReturn(Optional.of(lunch2));
+        lenient().when(lunchRepository.findById(3L)).thenReturn(Optional.of(lunch3));
+
+        lenient().when(memberRepository.findById(1L)).thenReturn(Optional.of(member1));
+        lenient().when(memberRepository.findById(2L)).thenReturn(Optional.of(member2));
+
+        lenient().when(lunchPollRepository.findByMemberAndLunch(member1, lunch2)).thenReturn(Optional.of(lunchPoll));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1, 1, 1, 0", "2, 1, 1, 1"})
+    @DisplayName("점심 메뉴에 투표한다.")
+    void Given_MemberIdAndLunchId_When_SaveLunchPoll_Then_Succeed(Long memberId, Long lunchId,
+                                                                  Long expectedLunch1PollCount,
+                                                                  Long expectedLunch2PollCount) {
+
+        // given
+        lenient().when(lunchPollRepository.findByMemberAndPolledAt(member1, today)).thenReturn(lunchPoll);
+        lenient().when(lunchPollRepository.findByMemberAndPolledAt(member2, today)).thenReturn(null);
+
+        // when
+        PostLunchPollResDto postLunchPollResDto = lunchPollService.saveLunchPoll(memberId, lunchId);
+
+        // then
+        assertAll(
+                () -> assertEquals(expectedLunch1PollCount, postLunchPollResDto.getPollCount()),
+                () -> assertEquals(expectedLunch2PollCount, lunch2.getLunchPolls().size())
+        );
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 점심 메뉴에 투표하려는 경우 예외를 던진다.")
+    void Given_InvalidLunchId_When_SaveLunchPoll_Then_ThrowException() {
+
+        // given
+        Long memberId = 1L;
+        Long lunchId = 4L;
+
+        // when, then
+        LunchException exception = assertThrows(LunchException.class, () -> lunchPollService.saveLunchPoll(memberId, lunchId));
+        assertEquals(LunchErrorInfo.INVALID_LUNCH_ID, exception.getInfo());
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버 아이디로 투표하려는 경우 예외를 던진다.")
+    void Given_InvalidMemberId_When_SaveLunchPoll_Then_ThrowException() {
+
+        // given
+        Long memberId = 3L;
+        Long lunchId = 1L;
+
+        // when, then
+        MemberException exception = assertThrows(MemberException.class, () -> lunchPollService.saveLunchPoll(memberId, lunchId));
+        assertEquals(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID, exception.getInfo());
+
+    }
+
+    @Test
+    @DisplayName("이미 투표한 점심 메뉴에 재투표할 경우 예외를 던진다.")
+    void Given_AlreadyPolledLunchId_When_SaveLunchPoll_Then_ThrowException() {
+
+        // given
+        Long memberId = 1L;
+        Long lunchId = 2L;
+        given(lunchPollRepository.findByMemberAndPolledAt(member1, today)).willReturn(lunchPoll);
+
+        // when, then
+        LunchException exception = assertThrows(LunchException.class, () -> lunchPollService.saveLunchPoll(memberId, lunchId));
+        assertEquals(LunchErrorInfo.DUPLICATE_LUNCH_POLL, exception.getInfo());
+
+        verify(lunchPollRepository).findByMemberAndPolledAt(member1, today);
+    }
+
+    @Test
+    @DisplayName("당일의 메뉴가 아닌 투표의 경우 예외를 던진다.")
+    void Given_NotTodayLunchId_When_SaveLunchPoll_Then_ThrowException() {
+
+        // given
+        Long lunchId = 3L;
+        Long memberId = 1L;
+
+        // when, then
+        LunchException exception = assertThrows(LunchException.class, () -> lunchPollService.saveLunchPoll(memberId, lunchId));
+        assertEquals(LunchErrorInfo.INVALID_DATE, exception.getInfo());
+
+    }
+
+    @Test
+    @DisplayName("점심 메뉴 투표를 취소한다.")
+    void Given_MemberIdAndLunchId_When_DeleteLunchPoll_Then_Succeed() {
+
+        // given
+        Long memberId = 1L;
+        Long lunchId = 2L;
+
+        // when
+        PostLunchPollResDto postLunchPollResDto = lunchPollService.deleteLunchPoll(memberId, lunchId);
+
+        // then
+        assertEquals(0, postLunchPollResDto.getPollCount());
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 점심 메뉴에 대해서 투표를 취소하려는 경우 예외를 던진다.")
+    void Given_InvalidLunchId_When_DeleteLunchPoll_Then_ThrowException() {
+
+        // given
+        Long memberId = 1L;
+        Long lunchId = 4L;
+
+        // when, then
+        LunchException exception = assertThrows(LunchException.class, () -> lunchPollService.deleteLunchPoll(memberId, lunchId));
+        assertEquals(LunchErrorInfo.INVALID_LUNCH_ID, exception.getInfo());
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 투표의 경우 예외를 던진다.")
+    void Given_NotPolledLunchPoll_When_DeleteLunchPoll_Then_ThrowException() {
+
+        // given
+        Long memberId = 2L;
+        Long lunchId = 1L;
+
+        // when, then
+        LunchException exception = assertThrows(LunchException.class, () -> lunchPollService.deleteLunchPoll(memberId, lunchId));
+        assertEquals(LunchErrorInfo.NO_LUNCH_POLL, exception.getInfo());
+
+    }
+
+    @Test
+    @DisplayName("당일의 메뉴가 아닌 투표의 경우 예외를 던진다.")
+    void Given_NotTodayLunchId_When_DeleteLunchPoll_Then_ThrowException() {
+
+        // given
+        Long lunchId = 3L;
+        Long memberId = 1L;
+
+        // when, then
+        LunchException exception = assertThrows(LunchException.class, () -> lunchPollService.deleteLunchPoll(memberId, lunchId));
+        assertEquals(LunchErrorInfo.INVALID_DATE, exception.getInfo());
+
+    }
+
+}

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListElementResDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListReqDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListResDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchResDto;
+import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
 import com.ssafy.ssafsound.domain.member.domain.Member;
@@ -30,11 +31,11 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -147,13 +148,26 @@ class LunchServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 캠퍼스로 점심 메뉴 목록 조회시 예외를 던진다.")
-    void Given_InvalidCampus_When_FindingAllLunches_Then_ThrowException() {
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 날짜의 점심 메뉴 목록 조회시 예외를 던진다.")
+    @DisplayName("유효하지 않은 날짜로 점심 메뉴 목록 조회시 예외를 던진다.")
     void Given_InvalidDate_When_FindingAllLunches_Then_ThrowException() {
+        // given
+        given(clock.instant()).willReturn(Instant.parse(testLocalDateTime));
+        given(clock.getZone()).willReturn(ZoneId.of("Asia/Seoul"));
+        String inputCampus = "서울";
+        LocalDate inputDate = today.minusDays(1);
+        Long memberId = member1.getId();
+
+        GetLunchListReqDto getLunchListReqDto = GetLunchListReqDto.builder()
+                .campus(inputCampus)
+                .date(inputDate)
+                .build();
+
+        // when
+        // then
+        assertThrows(LunchException.class, () -> lunchService.findLunches(memberId, getLunchListReqDto));
+
+        verify(clock).instant();
+        verify(clock).getZone();
     }
 
     // 점심 메뉴 상세 조회 테스트
@@ -177,5 +191,13 @@ class LunchServiceTest {
     @Test
     @DisplayName("유효하지 않은 날짜의 점심 아이디의 점심 메뉴 상세 조회 요청 시 예외를 던진다.")
     void Given_InValidDateLunch_When_FindLunchDetail_Then_ThrowException(){
+
+        // given
+        given(lunchRepository.findById(3L)).willReturn(Optional.empty());
+        Long lunchId = 3L;
+
+        // when
+        // then
+        assertThrows(LunchException.class, () -> lunchService.findLunchDetail(lunchId));
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListElementResDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListReqDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListResDto;
 import com.ssafy.ssafsound.domain.lunch.dto.GetLunchResDto;
+import com.ssafy.ssafsound.domain.lunch.exception.LunchErrorInfo;
 import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
@@ -35,8 +36,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -162,6 +162,7 @@ class LunchServiceTest {
         // given
         given(clock.instant()).willReturn(Instant.parse(testLocalDateTime));
         given(clock.getZone()).willReturn(ZoneId.of("Asia/Seoul"));
+
         String inputCampus = "서울";
         LocalDate inputDate = today.minusDays(1);
         Long memberId = member1.getId();
@@ -173,7 +174,8 @@ class LunchServiceTest {
 
         // when
         // then
-        assertThrows(LunchException.class, () -> lunchService.findLunches(memberId, getLunchListReqDto));
+        LunchException exception = assertThrows(LunchException.class, () -> lunchService.findLunches(memberId, getLunchListReqDto));
+        assertEquals(LunchErrorInfo.INVALID_DATE, exception.getInfo());
 
         verify(clock).instant();
         verify(clock).getZone();
@@ -198,15 +200,19 @@ class LunchServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 날짜의 점심 아이디의 점심 메뉴 상세 조회 요청 시 예외를 던진다.")
+    @DisplayName("유효하지 않은 점심 아이디의 점심 메뉴 상세 조회 요청 시 예외를 던진다.")
     void Given_InValidDateLunch_When_FindLunchDetail_Then_ThrowException(){
 
         // given
-        given(lunchRepository.findById(3L)).willReturn(Optional.empty());
         Long lunchId = 3L;
+
+        given(lunchRepository.findById(3L)).willReturn(Optional.empty());
 
         // when
         // then
-        assertThrows(LunchException.class, () -> lunchService.findLunchDetail(lunchId));
+        LunchException exception = assertThrows(LunchException.class, () -> lunchService.findLunchDetail(lunchId));
+        assertEquals(LunchErrorInfo.INVALID_LUNCH_ID, exception.getInfo());
+
+        verify(lunchRepository).findById(3L);
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
@@ -12,25 +12,26 @@ import com.ssafy.ssafsound.domain.meta.domain.Campus;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
+import com.ssafy.ssafsound.global.util.NullableConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class LunchServiceTest {
@@ -47,102 +48,84 @@ class LunchServiceTest {
 
     private Lunch lunch1;
     private Lunch lunch2;
-    private Lunch lunch3;
-    private Lunch lunch4;
     private Member member1;
     private Member member2;
-    private LunchPoll lunchPoll1;
-    private LunchPoll lunchPoll2;
-    private List<String> mainMenus;
+    private LunchPoll lunchPoll;
     private LocalDate today = LocalDate.now();
     private LocalDate tomorrow = today.plusDays(1);
-    private MetaData campus1;
-    private MetaData campus2;
+    private MetaData testCampus;
 
     @BeforeEach
     void setUp() {
-        mainMenus = new ArrayList<>();
 
-        // 테스트용 코스명 생성
-        for (int i = 0; i < 4; i++) {
-            mainMenus.add(String.format("mainMenu%d", i));
-        }
-
-        // 테스트용 캠퍼스 메타데이터 생성
-        campus1 = new MetaData(Campus.SEOUL);
-        campus2 = new MetaData(Campus.GUMI);
+        testCampus = new MetaData(Campus.SEOUL);
 
         lunch1 = Lunch.builder()
                 .id(1L)
-                .campus(campus1)
-                .mainMenu(mainMenus.get(0))
+                .campus(testCampus)
+                .mainMenu("mainMenu1")
                 .createdAt(today)
                 .build();
 
         lunch2 = Lunch.builder()
                 .id(2L)
-                .campus(campus1)
-                .mainMenu(mainMenus.get(1))
-                .createdAt(today)
-                .build();
-
-        lunch3 = Lunch.builder()
-                .id(3L)
-                .campus(campus1)
-                .mainMenu(mainMenus.get(2))
-                .createdAt(tomorrow)
-                .build();
-
-        lunch4 = Lunch.builder()
-                .id(4L)
-                .campus(campus2)
-                .mainMenu(mainMenus.get(3))
+                .campus(testCampus)
+                .mainMenu("mainMenu2")
                 .createdAt(today)
                 .build();
 
         member1 = Member.builder()
                 .id(1L)
                 .build();
+
         member2 = Member.builder()
                 .id(2L)
                 .build();
 
-        lunchPoll1 = LunchPoll.builder()
+        lunchPoll = LunchPoll.builder()
                 .lunch(lunch2)
                 .member(member1)
-                .polledAt(today)
-                .build();
-
-        lunchPoll2 = LunchPoll.builder()
-                .lunch(lunch2)
-                .member(member2)
                 .polledAt(today)
                 .build();
     }
 
     // 점심 메뉴 목록 조회 테스트
     @ParameterizedTest
-    @CsvSource({})
-    @DisplayName("캠퍼스와 당일 날짜로 점심 메뉴 목록을 조회한다.")
-    void Given_TodayDateAndCampus_When_FindLunches_Then_Succeed() {
+    @CsvSource({"1, 서울, 2023-07-10, 0", "2, 서울, 2023-07-10, -1", "null, 서울, 2023-07-10, -1"})
+    @DisplayName("캠퍼스와 날짜로 점심 메뉴 목록을 조회한다.")
+    void Given_TodayDateAndCampus_When_FindLunches_Then_Succeed(@ConvertWith(NullableConverter.class)Long memberId, String inputCampus, LocalDate inputDate,
+                                                                Long outputPolledAt) {
 
         // given
-        GetLunchListReqDto parameter = GetLunchListReqDto.builder().campus("서울").date(today).build();
-        given(metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), parameter.getCampus())).willReturn(campus1);
-        given(lunchRepository.findAllByCampusAndDate(campus1, today)).willReturn(Optional.of(List.of(lunch2, lunch1)));
+        given(metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), inputCampus))
+                .willReturn(new MetaData(Campus.SEOUL));
+
+        given(lunchRepository.findAllByCampusAndDate(metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), inputCampus), inputDate))
+                .willReturn(Optional.of(List.of(lunch2, lunch1)));
+
+        given(lunchPollRepository.findByMember_IdAndPolledAt(1L, inputDate))
+                .willReturn(lunchPoll);
+
+        given(lunchPollRepository.findByMember_IdAndPolledAt(2L, inputDate))
+                .willReturn(null);
+
+        GetLunchListReqDto getLunchListReqDto = GetLunchListReqDto.builder()
+                .campus(inputCampus)
+                .date(inputDate)
+                .build();
 
         // when
-        GetLunchListResDto result = lunchService.findLunches(null, parameter);
+        GetLunchListResDto result = lunchService.findLunches(memberId, getLunchListReqDto);
 
         // then
         assertAll(
                 () -> assertThat(result.getMenus().get(0))
                         .usingRecursiveComparison()
-                        .isEqualTo(GetLunchListElementResDto.of(lunch2,2L)),
+                        .isEqualTo(GetLunchListElementResDto.of(lunch2,1L)),
                 () -> assertThat(result.getMenus().get(1))
                         .usingRecursiveComparison()
-                        .isEqualTo(GetLunchListElementResDto.of(lunch1,2L)),
-                ()-> assertThat(result.getPolledAt()).isEqualTo(-1)
+                        .isEqualTo(GetLunchListElementResDto.of(lunch1,0L)),
+                ()-> assertThat(result.getPolledAt()).isEqualTo(outputPolledAt)
         );
     }
 

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
@@ -10,6 +10,7 @@ import com.ssafy.ssafsound.domain.lunch.exception.LunchException;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
 import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.meta.domain.Campus;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
@@ -46,6 +47,10 @@ class LunchServiceTest {
     private LunchRepository lunchRepository;
     @Mock
     private LunchPollRepository lunchPollRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
     @Mock
     private MetaDataConsumer metaDataConsumer;
     @Mock
@@ -96,6 +101,14 @@ class LunchServiceTest {
                 .member(member1)
                 .polledAt(today)
                 .build();
+
+        lenient().when(memberRepository.findById(1L)).thenReturn(Optional.of(member1));
+        lenient().when(memberRepository.findById(2L)).thenReturn(Optional.of(member2));
+
+        lenient().when(lunchPollRepository.findByMemberAndPolledAt(member1, today))
+                .thenReturn(lunchPoll);
+        lenient().when(lunchPollRepository.findByMemberAndPolledAt(member2, today))
+                .thenReturn(null);
     }
 
     // 점심 메뉴 목록 조회 테스트
@@ -114,11 +127,6 @@ class LunchServiceTest {
 
         given(lunchRepository.findAllByCampusAndDate(metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), inputCampus), inputDate))
                 .willReturn(Optional.of(Arrays.asList(lunch2, lunch1)));
-
-        if (memberId != null) {
-            lenient().when(lunchPollRepository.findByMember_IdAndPolledAt(memberId, inputDate))
-                    .thenReturn(memberId.equals(1L) ? lunchPoll : null);
-        }
 
         GetLunchListReqDto getLunchListReqDto = GetLunchListReqDto.builder()
                 .campus(inputCampus)
@@ -150,6 +158,7 @@ class LunchServiceTest {
     @Test
     @DisplayName("유효하지 않은 날짜로 점심 메뉴 목록 조회시 예외를 던진다.")
     void Given_InvalidDate_When_FindingAllLunches_Then_ThrowException() {
+
         // given
         given(clock.instant()).willReturn(Instant.parse(testLocalDateTime));
         given(clock.getZone()).willReturn(ZoneId.of("Asia/Seoul"));

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
@@ -2,8 +2,17 @@ package com.ssafy.ssafsound.domain.lunch.service;
 
 import com.ssafy.ssafsound.domain.lunch.domain.Lunch;
 import com.ssafy.ssafsound.domain.lunch.domain.LunchPoll;
+import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListElementResDto;
+import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListReqDto;
+import com.ssafy.ssafsound.domain.lunch.dto.GetLunchListResDto;
+import com.ssafy.ssafsound.domain.lunch.repository.LunchPollRepository;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import com.ssafy.ssafsound.domain.meta.domain.Campus;
+import com.ssafy.ssafsound.domain.meta.domain.MetaData;
+import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,15 +21,23 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class LunchServiceTest {
 
     @Mock
     private LunchRepository lunchRepository;
-
+    @Mock
+    private LunchPollRepository lunchPollRepository;
     @Mock
     private MetaDataConsumer metaDataConsumer;
 
@@ -28,55 +45,151 @@ class LunchServiceTest {
     private LunchService lunchService;
 
     private List<Lunch> lunches;
+    private List<Member> members;
     private List<LunchPoll> lunchPolls;
-
-
+    private List<String> mainMenus;
+    private LocalDate today = LocalDate.now();
+    private LocalDate tomorrow = today.plusDays(1);
+    private MetaData campus1;
+    private MetaData campus2;
 
     @BeforeEach
     void setUp() {
         lunches = new ArrayList<>();
+        members = new ArrayList<>();
         lunchPolls = new ArrayList<>();
+        mainMenus = new ArrayList<>();
 
-        for(int i = 0; i < 10; i++){
-            lunches.add(Lunch.builder()
-                    .id((long)i)
-                    .campus(metaDataConsumer.getMetaData("",""))
-                    .build());
+        // 테스트용 코스명 생성
+        for (int i = 0; i < 10; i++) {
+            mainMenus.add(String.format("mainMenu%d", i));
+        }
+
+        // 테스트용 캠퍼스 메타데이터 생성
+        campus1 = new MetaData(Campus.SEOUL);
+        campus2 = new MetaData(Campus.GUMI);
+
+        // Lunch 10개 생성
+        for (long i = 0; i < 10; i++) {
+
+            lunches.add(
+                    Lunch.builder()
+                            .id(i)
+                            .campus(i < 5 ? campus1 : campus2)
+                            .mainMenu(mainMenus.get((int) i))
+                            .createdAt(i % 2 == 0 ? today : tomorrow)
+                            .build());
+        }
+
+        // Member 5개 생성하고 투표
+        for (long i = 0; i < 5; i++) {
+
+            Member member = Member.builder()
+                    .id(i)
+                    .build();
+
+            members.add(member);
+
+            lunchPolls.add(
+                    LunchPoll.builder()
+                            .lunch(i < 3 ? lunches.get(2) : lunches.get(4))
+                            .member(member)
+                            .polledAt(today)
+                            .build()
+            );
+
+            lunchPolls.add(
+                    LunchPoll.builder()
+                            .lunch(i < 3 ? lunches.get(8) : lunches.get(6))
+                            .member(member)
+                            .polledAt(today)
+                            .build()
+            );
         }
     }
 
+    // 점심 메뉴 목록 조회 테스트
     @Test
-    @DisplayName("정상 파라미터 요청시 점심 메뉴 목록 조회 성공")
-    void Given_ValidArgument_When_FindingAllLunchesBriefly_Then_Succeed() {
+    @DisplayName("캠퍼스와 당일 날짜로 점심 메뉴 목록을 조회한다.")
+    void Given_TodayDateAndCampus_When_FindLunches_Then_Succeed() {
+
+        // given
+        GetLunchListReqDto parameter = GetLunchListReqDto.builder()
+                .campus("서울")
+                .date(today)
+                .build();
+        given(metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), parameter.getCampus())).willReturn(campus1);
+        given(lunchRepository.findAllByCampusAndDate(campus1, today))
+                .willReturn(Optional.of(lunches.stream()
+                        .filter(
+                                (lunch -> lunch.getCampus().getName().equals(campus1.getName()) && lunch.getCreatedAt() == today)
+                        ).collect(Collectors.toList()))
+                );
+
+        // when
+        GetLunchListResDto result = lunchService.findLunches(null, parameter);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getMenus().get(0))
+                        .usingRecursiveComparison()
+                        .isEqualTo(GetLunchListElementResDto.of(lunches.get(2),3L)),
+                () -> assertThat(result.getMenus().get(1))
+                        .usingRecursiveComparison()
+                        .isEqualTo(GetLunchListElementResDto.of(lunches.get(4),2L)),
+                () -> assertThat(result.getMenus().get(2))
+                        .usingRecursiveComparison()
+                        .isEqualTo(GetLunchListElementResDto.of(lunches.get(0),0L)),
+                ()-> assertThat(result.getPolledAt()).isEqualTo(-1)
+        );
+
+
     }
 
     @Test
-    @DisplayName("잘못된 타입의 파라미터 요청시 점심 메뉴 목록 조회 실패")
-    void Given_IllegalArgument_When_FindingAllLunchesBriefly_Then_ThrowException() {
+    @DisplayName("캠퍼스와 익일 날짜로 점심 메뉴 목록을 조회한다.")
+    void Given_TomorrowDateAndCampus_When_FindLunches_Then_Succeed() {
+
     }
 
     @Test
-    @DisplayName("유효하지 않은 캠퍼스 요청시 점심 메뉴 목록 조회 실패")
-    void Given_InvalidCampus_When_FindingAllLunchesBriefly_Then_ThrowException() {
+    @DisplayName("캠퍼스와 당일 날짜, 멤버 아이디로 투표 정보가 포함된 점심 메뉴 목록을 조회한다.")
+    void Given_TodayDateAndCampusWithMemberId_When_FindLunches_Then_Succeed() {
     }
 
     @Test
-    @DisplayName("유효하지 않은 날짜 요청시 점심 메뉴 목록 조회 성공")
-    void Given_InvalidDate_When_FindingAllLunchesBriefly_Then_ThrowException() {
+    @DisplayName("캠퍼스와 날짜로 요청시 정보가 없는 점심 메뉴 목록 조회 성공")
+    void Given_ValidArgument_When_FindLunchesWithEmptyResult_Then_Succeed() {
     }
 
     @Test
-    @DisplayName("정상 경로 요청시 점심 메뉴 상세 조회 성공")
-    void Given_ValidPathVariable_When_FindingALunchDetail_Then_Succeed(){
+    @DisplayName("잘못된 타입의 파라미터로 점심 메뉴 목록 조회시 예외를 던진다.")
+    void Given_IllegalArgument_When_FindLunches_Then_ThrowException() {
     }
 
     @Test
-    @DisplayName("정상 점심 아이디 요청시 점심 메뉴 상세 조회 성공")
-    void Given_ValidId_When_FindingALunchDetail_Then_Succeed(){
+    @DisplayName("유효하지 않은 캠퍼스로 점심 메뉴 목록 조회시 예외를 던진다.")
+    void Given_InvalidCampus_When_FindingAllLunches_Then_ThrowException() {
     }
 
     @Test
-    @DisplayName("유효하지 않은 점심 아이디 요청시 점심 메뉴 상세 조회 실패")
-    void Given_InvalidId_When_FindingALunchDetail_Then_Succeed(){
+    @DisplayName("유효하지 않은 날짜의 점심 메뉴 목록 조회시 예외를 던진다.")
+    void Given_InvalidDate_When_FindingAllLunches_Then_ThrowException() {
+    }
+
+    // 점심 메뉴 상세 조회 테스트
+    @Test
+    @DisplayName("점심 아이디를 경로로 점심 상세 정보를 조회한다.")
+    void Given_ValidLunch_When_FindLunchDetail_Then_Succeed(){
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 날짜의 점심 아이디의 점심 메뉴 상세 조회 요청 시 예외를 던진다.")
+    void Given_InValidDateLunch_When_FindLunchDetail_Then_ThrowException(){
+    }
+
+    @Test
+    @DisplayName("잘못된 타입의 경로의 점심 메뉴 상세 조회 요청 시 예외를 던진다.")
+    void Given_IllegalArgument_When_FindLunchDetail_Then_Succeed(){
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
@@ -12,7 +12,6 @@ import com.ssafy.ssafsound.domain.meta.domain.Campus;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -149,6 +148,39 @@ class LunchServiceTest {
     @Test
     @DisplayName("캠퍼스와 익일 날짜로 점심 메뉴 목록을 조회한다.")
     void Given_TomorrowDateAndCampus_When_FindLunches_Then_Succeed() {
+
+        // given
+        GetLunchListReqDto parameter = GetLunchListReqDto.builder()
+                .campus("서울")
+                .date(tomorrow)
+                .build();
+
+        given(metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), parameter.getCampus())).willReturn(campus1);
+
+        for (int i = 0; i < 5; i++) {
+            given(lunchPollRepository.findByMember_IdAndPolledAt())
+                    .willReturn()
+        }
+        given(lunchRepository.findAllByCampusAndDate(campus1, tomorrow))
+                .willReturn(Optional.of(lunches.stream()
+                        .filter(
+                                (lunch -> lunch.getCampus().getName().equals(campus1.getName()) && lunch.getCreatedAt() == tomorrow)
+                        ).collect(Collectors.toList()))
+                );
+
+        // when
+        GetLunchListResDto result = lunchService.findLunches(1L, parameter);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getMenus().get(0))
+                        .usingRecursiveComparison()
+                        .isEqualTo(GetLunchListElementResDto.of(lunches.get(1),0L)),
+                () -> assertThat(result.getMenus().get(1))
+                        .usingRecursiveComparison()
+                        .isEqualTo(GetLunchListElementResDto.of(lunches.get(3),0L)),
+                ()-> assertThat(result.getPolledAt()).isEqualTo(-1)
+        );
 
     }
 

--- a/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/lunch/service/LunchServiceTest.java
@@ -1,6 +1,9 @@
 package com.ssafy.ssafsound.domain.lunch.service;
 
+import com.ssafy.ssafsound.domain.lunch.domain.Lunch;
+import com.ssafy.ssafsound.domain.lunch.domain.LunchPoll;
 import com.ssafy.ssafsound.domain.lunch.repository.LunchRepository;
+import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,7 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class LunchServiceTest {
@@ -17,12 +21,28 @@ class LunchServiceTest {
     @Mock
     private LunchRepository lunchRepository;
 
+    @Mock
+    private MetaDataConsumer metaDataConsumer;
+
     @InjectMocks
     private LunchService lunchService;
 
+    private List<Lunch> lunches;
+    private List<LunchPoll> lunchPolls;
+
+
+
     @BeforeEach
     void setUp() {
+        lunches = new ArrayList<>();
+        lunchPolls = new ArrayList<>();
 
+        for(int i = 0; i < 10; i++){
+            lunches.add(Lunch.builder()
+                    .id((long)i)
+                    .campus(metaDataConsumer.getMetaData("",""))
+                    .build());
+        }
     }
 
     @Test

--- a/src/test/java/com/ssafy/ssafsound/global/util/NullableConverter.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/NullableConverter.java
@@ -1,0 +1,16 @@
+package com.ssafy.ssafsound.global.util;
+
+import org.junit.jupiter.params.converter.DefaultArgumentConverter;
+import org.junit.jupiter.params.converter.SimpleArgumentConverter;
+
+public final class NullableConverter extends SimpleArgumentConverter {
+
+    @Override
+    public Object convert(Object source, Class<?> targetType) {
+        if ("null".equals(source)) {
+            return null;
+        }
+
+        return DefaultArgumentConverter.INSTANCE.convert(source, targetType);
+    }
+}


### PR DESCRIPTION
## Issues

- #

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 테스트 코드가 너무 길어져서 기존에 LunchService에 몰려있던 Lunch와 LunchPoll 로직을 LunchService와 LunchPollService로 분리했습니다.
- assertThrows로 예외 테스트 시에 예외 종류가 도메인마다 똑같기 때문에, 구분을 위해서 Exception의 enum 필드인 ErrorInfo 까지 검증했습니다.
- 기존에 memberId를 이용해 직접 쿼리를 보내던 방식에서, MemberRepository에서 Member 엔티티를 조회해서 사용하는 방식으로 변경했습니다.
- @CsvSource를 이용하여 테스트 시에 디폴트 컨버터로는 인풋 파라미터 객체 값으로 null을 할당할 수 없습니다. 따라서 NullableConverter를 구현했고, test.java.com.ssafy.ssafsound.global.util에 위치시켰습니다. 사용 방법은 다음과 같습니다.
```java
void SampleTest (@ConvertWith(NullableConverter.class) Long memberId, String inputCampus, LocalDate inputDate, Long outputPolledAt) { ....
``` 
- 타임머신 테스트를 위해서 TimeConfig를 추가했습니다. 기존에는 현재 시간이라는 값을 로직에서 사용할 때는 LocalDateTime.now() 라는 static 메소드를 사용했습니다. 하지만 static 메소드는 테스트 시에 모킹이 어렵기 때문에, Clock이라는 객체를 주입받아서 Clock을 이용해서 현재시간을 받는 형태로 변경했습니다. 그래서 테스트에서도 Clock를 mocking 하고 `clock.instant()`, `clock.getZone()` 이 두가지 메소드를 모킹해주면 원하는 시간을 리턴하도록 설정이 가능합니다. 또한 기존의 LocalDateTime.now()와 같은 코드가 적용 되어 있는 경우 다음과 같이 변경해주시면 편하게 테스트 코드 작성이 가능합니다.
```java
@Autowired
private final Clock clock;

...
LocalDateTime.now(Clock);

```

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
