### PR TITLE
refactor: 리크루트 참여자 조회 수정

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/GetRecruitLimitDetail.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/GetRecruitLimitDetail.java
@@ -1,0 +1,32 @@
+package com.ssafy.ssafsound.domain.recruit.domain;
+
+import com.ssafy.ssafsound.domain.recruit.dto.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetRecruitLimitDetail extends RecruitLimitElement {
+    private int currentNumber;
+
+    @Override
+    public void addRegisterLimit() {
+        super.addRegisterLimit();
+        currentNumber++;
+    }
+
+    public GetRecruitLimitDetail(String recruitType, Integer limit, Integer currentNumber) {
+        super(recruitType, limit);
+        this.currentNumber = currentNumber;
+    }
+
+    public static GetRecruitLimitDetail from(RecruitLimitation recruitLimitation) {
+        return new GetRecruitLimitDetail(
+                recruitLimitation.getType().getName(),
+                recruitLimitation.getLimitation(),
+                recruitLimitation.getCurrentNumber()
+        );
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitDetailResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitDetailResDto.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafsound.domain.recruit.dto;
 
 import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.dto.SSAFYInfo;
+import com.ssafy.ssafsound.domain.recruit.domain.GetRecruitLimitDetail;
 import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitErrorInfo;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitException;
@@ -24,7 +25,7 @@ public class GetRecruitDetailResDto {
     private String recruitStart;
     private String recruitEnd;
     private List<RecruitSkillElement> skills;
-    private List<RecruitLimitElement> limits;
+    private List<GetRecruitLimitDetail> limits;
     private long memberId;
     private String nickName;
     private Boolean isMajor;
@@ -39,8 +40,8 @@ public class GetRecruitDetailResDto {
                 .map(RecruitSkillElement::from)
                 .collect(Collectors.toList());
 
-        List<RecruitLimitElement> limits = recruit.getLimitations().stream()
-                .map(RecruitLimitElement::from)
+        List<GetRecruitLimitDetail> limits = recruit.getLimitations().stream()
+                .map(GetRecruitLimitDetail::from)
                 .collect(Collectors.toList());
 
         String registerRecruitType = recruit.getRegisterRecruitType().getName();
@@ -69,8 +70,8 @@ public class GetRecruitDetailResDto {
                 .build();
     }
 
-    private static void addRegisterRecruitType(List<RecruitLimitElement> limits, String registerRecruitType) {
-        for(RecruitLimitElement limit: limits) {
+    private static void addRegisterRecruitType(List<GetRecruitLimitDetail> limits, String registerRecruitType) {
+        for(GetRecruitLimitDetail limit: limits) {
             if(limit.getRecruitType().equals(registerRecruitType)) {
                 limit.addRegisterLimit();
                 return;
@@ -78,6 +79,6 @@ public class GetRecruitDetailResDto {
         }
 
         // 리크루트 등록 시 모집 인원 제한에 등록자가 포함되지 않는 경우 인원 제한 타입을 추가한다.
-        limits.add(new RecruitLimitElement(registerRecruitType, 1));
+        limits.add(new GetRecruitLimitDetail(registerRecruitType, 1, 1));
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PostRecruitReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/PostRecruitReqDto.java
@@ -1,8 +1,6 @@
 package com.ssafy.ssafsound.domain.recruit.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
-import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
 import com.ssafy.ssafsound.domain.recruit.validator.CheckRecruitLimitElement;
 import com.ssafy.ssafsound.domain.recruit.validator.CheckRecruitType;
 import com.ssafy.ssafsound.domain.meta.validator.CheckSkills;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitLimitationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitLimitationRepository.java
@@ -3,5 +3,8 @@ package com.ssafy.ssafsound.domain.recruit.repository;
 import com.ssafy.ssafsound.domain.recruit.domain.RecruitLimitation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RecruitLimitationRepository extends JpaRepository<RecruitLimitation, Long> {
+    List<RecruitLimitation> findByRecruitId(Long recruitId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitParticipantsResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/GetRecruitParticipantsResDto.java
@@ -1,25 +1,45 @@
 package com.ssafy.ssafsound.domain.recruitapplication.dto;
 
 import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
+import com.ssafy.ssafsound.domain.recruit.domain.RecruitLimitation;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
 public class GetRecruitParticipantsResDto {
-    List<RecruitParticipantElement> members;
+    private Map<String, RecruitParticipantElement> recruitTypes;
 
-    public static GetRecruitParticipantsResDto from(List<RecruitApplication> recruitApplications) {
-        return new GetRecruitParticipantsResDto(recruitApplications.stream()
-                .map(RecruitParticipantElement::from)
-                .collect(Collectors.toList()));
+    public static GetRecruitParticipantsResDto of(List<RecruitApplication> recruitApplications, List<RecruitLimitation> recruitLimitations) {
+        Map<String, RecruitParticipantElement> participantElementMap = new HashMap<>();
+
+        recruitLimitations.forEach(recruitLimitation -> {
+            String recruitType = recruitLimitation.getType().getName();
+            participantElementMap.put(recruitType, new RecruitParticipantElement(recruitLimitation.getLimitation()));
+        });
+
+        recruitApplications.forEach(recruitApplication -> {
+            String recruitType = recruitApplication.getType().getName();
+            participantElementMap.get(recruitType).addMember(recruitApplication.getMember());
+        });
+
+        return new GetRecruitParticipantsResDto(participantElementMap);
     }
 
     public void addRegisterInfo(Recruit recruit) {
-        this.members.add(RecruitParticipantElement.from(recruit));
+        String recruitType = recruit.getRegisterRecruitType().getName();
+        RecruitParticipantElement recruitParticipantElement = recruitTypes.get(recruitType);
+        if(recruitParticipantElement == null) {
+            recruitParticipantElement = new RecruitParticipantElement(0);
+            recruitTypes.put(recruitType, recruitParticipantElement);
+        }
+
+        recruitParticipantElement.addMember(recruit.getMember());
+        recruitParticipantElement.increaseLimit();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/ParticipantElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/ParticipantElement.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafsound.domain.recruitapplication.dto;
+
+import com.ssafy.ssafsound.domain.member.dto.SSAFYInfo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipantElement {
+    private Long memberId;
+    private String nickName;
+    private Boolean isMajor;
+    private SSAFYInfo ssafyInfo;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitParticipantElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/dto/RecruitParticipantElement.java
@@ -2,49 +2,38 @@ package com.ssafy.ssafsound.domain.recruitapplication.dto;
 
 import com.ssafy.ssafsound.domain.member.domain.Member;
 import com.ssafy.ssafsound.domain.member.dto.SSAFYInfo;
-import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
-import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
-@Builder
+@NoArgsConstructor
 public class RecruitParticipantElement {
-    private String recruitType;
-    private Long memberId;
-    private String nickName;
-    private Boolean isMajor;
-    private SSAFYInfo ssafyInfo;
+    private Integer limit;
+    private List<ParticipantElement> members;
 
-    public static RecruitParticipantElement from(RecruitApplication recruitApplication) {
-        Member member = recruitApplication.getMember();
+    public RecruitParticipantElement(Integer limit) {
+        this.limit = limit;
+        members = new ArrayList<>();
+    }
+
+    public void addMember(Member member) {
         SSAFYInfo ssafyInfo = null;
         if(member.getSsafyMember()) {
             ssafyInfo = SSAFYInfo.from(member);
         }
 
-        return RecruitParticipantElement.builder()
-                .recruitType(recruitApplication.getType().getName())
+        members.add(ParticipantElement.builder()
                 .memberId(member.getId())
                 .nickName(member.getNickname())
                 .isMajor(member.getMajor())
                 .ssafyInfo(ssafyInfo)
-                .build();
+                .build());
     }
 
-    public static RecruitParticipantElement from(Recruit recruit) {
-        Member register = recruit.getMember();
-        SSAFYInfo ssafyInfo = null;
-        if(register.getSsafyMember()) {
-            ssafyInfo = SSAFYInfo.from(register);
-        }
-
-        return RecruitParticipantElement.builder()
-                .recruitType(recruit.getRegisterRecruitType().getName())
-                .memberId(register.getId())
-                .nickName(register.getNickname())
-                .isMajor(register.getMajor())
-                .ssafyInfo(ssafyInfo)
-                .build();
+    public void increaseLimit() {
+        this.limit++;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -10,6 +10,7 @@ import com.ssafy.ssafsound.domain.recruit.domain.RecruitQuestion;
 import com.ssafy.ssafsound.domain.recruit.domain.RecruitQuestionReply;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitErrorInfo;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitException;
+import com.ssafy.ssafsound.domain.recruit.repository.RecruitLimitationRepository;
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitQuestionReplyRepository;
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
@@ -37,6 +38,7 @@ public class RecruitApplicationService {
     private final RecruitRepository recruitRepository;
     private final RecruitQuestionReplyRepository recruitQuestionReplyRepository;
     private final RecruitApplicationRepository recruitApplicationRepository;
+    private final RecruitLimitationRepository recruitLimitationRepository;
     private final MemberRepository memberRepository;
     private final MetaDataConsumer metaDataConsumer;
 
@@ -111,7 +113,9 @@ public class RecruitApplicationService {
         List<RecruitApplication> recruitApplications = recruitApplicationRepository
                 .findByRecruitIdAndMatchStatusFetchMember(recruitId, MatchStatus.DONE);
 
-        GetRecruitParticipantsResDto getRecruitParticipantsResDto = GetRecruitParticipantsResDto.from(recruitApplications);
+        List<RecruitLimitation> recruitLimitations = recruitLimitationRepository.findByRecruitId(recruitId);
+
+        GetRecruitParticipantsResDto getRecruitParticipantsResDto = GetRecruitParticipantsResDto.of(recruitApplications, recruitLimitations);
         getRecruitParticipantsResDto.addRegisterInfo(recruitRepository.findByIdFetchJoinRegister(recruitId));
         return getRecruitParticipantsResDto;
     }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -298,7 +298,6 @@ class RecruitApplicationServiceTest {
     @DisplayName("리크루트 참여자 목록 조회")
     @Test
     void Given_RecruitId_When_GetRecruitParticipants_Then_Success() {
-        recruitApplicationService.getRecruitParticipants(1L);
         GetRecruitParticipantsResDto dto = recruitApplicationService.getRecruitParticipants(1L);
 
         List<ParticipantElement> members = dto.getRecruitTypes().get(RecruitType.DESIGN.getName()).getMembers();

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -9,11 +9,13 @@ import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
 import com.ssafy.ssafsound.domain.recruit.domain.RecruitLimitation;
 import com.ssafy.ssafsound.domain.recruit.domain.RecruitQuestion;
 import com.ssafy.ssafsound.domain.recruit.exception.RecruitException;
+import com.ssafy.ssafsound.domain.recruit.repository.RecruitLimitationRepository;
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitQuestionReplyRepository;
 import com.ssafy.ssafsound.domain.recruit.repository.RecruitRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.GetRecruitParticipantsResDto;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.ParticipantElement;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.PostRecruitApplicationReqDto;
 import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicationRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +44,9 @@ class RecruitApplicationServiceTest {
 
     @Mock
     private RecruitQuestionReplyRepository recruitQuestionReplyRepository;
+
+    @Mock
+    private RecruitLimitationRepository recruitLimitationRepository;
 
     @Mock
     private MemberRepository memberRepository;
@@ -131,6 +136,8 @@ class RecruitApplicationServiceTest {
                 .thenReturn(java.util.Optional.ofNullable(recruitApplication));
         Mockito.lenient().when(recruitApplicationRepository.findByRecruitIdAndMatchStatusFetchMember(1L, MatchStatus.DONE))
                 .thenReturn(recruitApplications);
+        Mockito.lenient().when(recruitLimitationRepository.findByRecruitId(1L))
+                .thenReturn(limits);
 
         Mockito.lenient().when(memberRepository.getReferenceById(1L)).thenReturn(register);
         Mockito.lenient().when(memberRepository.getReferenceById(2L)).thenReturn(participant);
@@ -294,8 +301,10 @@ class RecruitApplicationServiceTest {
         recruitApplicationService.getRecruitParticipants(1L);
         GetRecruitParticipantsResDto dto = recruitApplicationService.getRecruitParticipants(1L);
 
+        List<ParticipantElement> members = dto.getRecruitTypes().get(RecruitType.DESIGN.getName()).getMembers();
+
         assertAll(
-                ()->assertEquals(2, dto.getMembers().size())
+                ()->assertEquals(2, members.size())
         );
     }
 


### PR DESCRIPTION
## Issues

- #129 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
1. 리크루트 단건 조회
현재 참여중인 인원의 숫자 추가 (currentNumber 추가)

2. 리크루트 참여자 목록 조회
→ 모집 파트별 인원 제한 추가 및 데이터 구조 변경 

기존 -> 모든 참여자에 RecruitType를 가지는 형태 
```javascript
                        "recruitType":  "기획/디자인",
                        "memberId": 2,
                        "nickName": "kds",
                        "isMajor": true,
                        "ssafyInfo": {
                            "semester": 9,
                            "campus": "서울",
                            "certificationState": "CERTIFIED",
                            "majorTrack": "Java"
                        }
```


변경 

```jacascript
{
    "code": "200",
    "message": "success",
    "data": {
        "recruitTypes": {
            "기획/디자인": {
                "limit": 3,
                "members": [
                    {
                        "memberId": 2,
                        "nickName": "kds",
                        "isMajor": true,
                        "ssafyInfo": {
                            "semester": 9,
                            "campus": "서울",
                            "certificationState": "CERTIFIED",
                            "majorTrack": "Java"
                        }
                    },
                    {
                        "memberId": 1,
                        "nickName": "khs",
                        "isMajor": true,
                        "ssafyInfo": {
                            "semester": 9,
                            "campus": "서울",
                            "certificationState": "CERTIFIED",
                            "majorTrack": "Java"
                        }
                    }
                ]
            }
        }
    }
}
```
recruitType별 인원 제한 및 신청 완료 참여자 형태로 수정 

수정 이유 : 기존에 화면을 그리기 위해서는  리크루트 디테일 조회를 선행적으로 불러야 리크루트 참여자 목록에 "인원제한"

을 구할 수 있엇는데,  이렇게 특정 API에 결과에 종속적으로 화면을 그리는 경우, 차후 프론트엔드에서 컴포넌트 재사용에 문제가 생기므로 수정 

요청

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
