### PR TITLE
feat: member 기본정보 수정 API

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -6,9 +6,7 @@ import com.ssafy.ssafsound.domain.member.dto.*;
 import com.ssafy.ssafsound.domain.member.service.MemberService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
-
 import javax.validation.Valid;
 
 @RestController

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafsound.domain.member.dto.*;
 import com.ssafy.ssafsound.domain.member.service.MemberService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -65,6 +66,15 @@ public class MemberController {
     public EnvelopeResponse registerMemberPortfolio(@Authentication AuthenticatedMember authenticatedMember,
                                                  @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
         memberService.registerMemberPortfolio(authenticatedMember, putMemberProfileReqDto);
+        return EnvelopeResponse.builder()
+                .build();
+    }
+
+    @PatchMapping("/default-information")
+    public EnvelopeResponse patchMemberDefaultInformation(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
+        memberService.patchMemberDefaultInf();
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -72,7 +72,7 @@ public class MemberController {
     public EnvelopeResponse patchMemberDefaultInformation(
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
-        memberService.patchMemberDefaultInfo(authenticatedMember, patchMemberDefaultInfoReqDto);
+        memberService.patchMemberDefaultInfo(authenticatedMember.getMemberId(), patchMemberDefaultInfoReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -74,7 +74,7 @@ public class MemberController {
     public EnvelopeResponse patchMemberDefaultInformation(
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
-        memberService.patchMemberDefaultInf();
+        memberService.patchMemberDefaultInfo(authenticatedMember, patchMemberDefaultInfoReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -4,6 +4,8 @@ import com.ssafy.ssafsound.domain.BaseTimeEntity;
 import com.ssafy.ssafsound.domain.member.dto.PatchMemberDefaultInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PutMemberLink;
+import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.meta.converter.CampusConverter;
 import com.ssafy.ssafsound.domain.meta.converter.MajorTrackConverter;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
@@ -149,6 +151,9 @@ public class Member extends BaseTimeEntity {
             PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto,
             MetaDataConsumer metaDataConsumer) {
         if (patchMemberDefaultInfoReqDto.getSsafyMember()) {
+            if(patchMemberDefaultInfoReqDto.isNotSemesterPresent()) {
+                throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
+            }
             this.ssafyMember = true;
             this.semester = patchMemberDefaultInfoReqDto.getSemester();
             this.campus = metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), patchMemberDefaultInfoReqDto.getCampus());

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -151,9 +151,6 @@ public class Member extends BaseTimeEntity {
     public void exchangeDefaultInformation(
             PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto, MetaDataConsumer metaDataConsumer) {
         if (patchMemberDefaultInfoReqDto.getSsafyMember()) {
-            if(patchMemberDefaultInfoReqDto.isNotSemesterPresent()) {
-                throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
-            }
             this.ssafyMember = true;
             this.semester = patchMemberDefaultInfoReqDto.getSemester();
             this.campus = metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), patchMemberDefaultInfoReqDto.getCampus());

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.member.domain;
 
 import com.ssafy.ssafsound.domain.BaseTimeEntity;
+import com.ssafy.ssafsound.domain.member.dto.PatchMemberDefaultInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PutMemberLink;
 import com.ssafy.ssafsound.domain.meta.converter.CampusConverter;
@@ -142,5 +143,17 @@ public class Member extends BaseTimeEntity {
         this.nickname = postMemberInfoReqDto.getNickname();
         this.ssafyMember = postMemberInfoReqDto.getSsafyMember();
         this.major = postMemberInfoReqDto.getIsMajor();
+    }
+
+    public void exchangeDefaultInformation(
+            PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto,
+            MetaDataConsumer metaDataConsumer) {
+        if (patchMemberDefaultInfoReqDto.getSsafyMember()) {
+            this.ssafyMember = true;
+            this.semester = patchMemberDefaultInfoReqDto.getSemester();
+            this.campus = metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), patchMemberDefaultInfoReqDto.getCampus());
+        } else {
+            this.ssafyMember = false;
+        }
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -151,6 +151,9 @@ public class Member extends BaseTimeEntity {
     public void exchangeDefaultInformation(
             PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto, MetaDataConsumer metaDataConsumer) {
         if (patchMemberDefaultInfoReqDto.getSsafyMember()) {
+            if(patchMemberDefaultInfoReqDto.getSemester() == null) {
+                throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
+            }
             this.ssafyMember = true;
             this.semester = patchMemberDefaultInfoReqDto.getSemester();
             this.campus = metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), patchMemberDefaultInfoReqDto.getCampus());

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.member.domain;
 
 import com.ssafy.ssafsound.domain.BaseTimeEntity;
+import com.ssafy.ssafsound.domain.member.dto.GetMemberResDto;
 import com.ssafy.ssafsound.domain.member.dto.PatchMemberDefaultInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberInfoReqDto;
 import com.ssafy.ssafsound.domain.member.dto.PutMemberLink;
@@ -148,8 +149,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public void exchangeDefaultInformation(
-            PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto,
-            MetaDataConsumer metaDataConsumer) {
+            PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto, MetaDataConsumer metaDataConsumer) {
         if (patchMemberDefaultInfoReqDto.getSsafyMember()) {
             if(patchMemberDefaultInfoReqDto.isNotSemesterPresent()) {
                 throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
@@ -159,6 +159,20 @@ public class Member extends BaseTimeEntity {
             this.campus = metaDataConsumer.getMetaData(MetaDataType.CAMPUS.name(), patchMemberDefaultInfoReqDto.getCampus());
         } else {
             this.ssafyMember = false;
+        }
+    }
+
+    public GetMemberResDto registerMemberInformation(
+            PostMemberInfoReqDto postMemberInfoReqDto, MetaDataConsumer metaDataConsumer) {
+        if (postMemberInfoReqDto.getSsafyMember()) {
+            if(postMemberInfoReqDto.isNotSemesterPresent()) {
+                throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
+            }
+            this.setSSAFYMemberInformation(postMemberInfoReqDto, metaDataConsumer);
+            return GetMemberResDto.fromSSAFYUser(this);
+        } else {
+            this.setGeneralMemberInformation(postMemberInfoReqDto);
+            return GetMemberResDto.fromGeneralUser(this);
         }
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberResDto.java
@@ -20,20 +20,20 @@ public class GetMemberResDto {
     private Boolean isMajor;
     private SSAFYInfo ssafyInfo;
 
-    public static GetMemberResDto fromGeneralUser(Member member, MemberRole memberRole) {
+    public static GetMemberResDto fromGeneralUser(Member member) {
         return GetMemberResDto.builder()
                 .memberId(member.getId())
-                .memberRole(memberRole.getRoleType())
+                .memberRole(member.getRole().getRoleType())
                 .nickname(member.getNickname())
                 .ssafyMember(member.getSsafyMember())
                 .isMajor(member.getMajor())
                 .build();
     }
 
-    public static GetMemberResDto fromSSAFYUser(Member member, MemberRole memberRole) {
+    public static GetMemberResDto fromSSAFYUser(Member member) {
         return GetMemberResDto.builder()
                 .memberId(member.getId())
-                .memberRole(memberRole.getRoleType())
+                .memberRole(member.getRole().getRoleType())
                 .nickname(member.getNickname())
                 .ssafyMember(member.getSsafyMember())
                 .isMajor(member.getMajor())

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberDefaultInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberDefaultInfoReqDto.java
@@ -19,4 +19,8 @@ public class PatchMemberDefaultInfoReqDto {
     private Integer semester;
 
     private String campus;
+
+    public boolean isNotSemesterPresent() {
+        return semester == null;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberDefaultInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberDefaultInfoReqDto.java
@@ -19,8 +19,4 @@ public class PatchMemberDefaultInfoReqDto {
     private Integer semester;
 
     private String campus;
-
-    public boolean isNotSemesterPresent() {
-        return semester == null;
-    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberDefaultInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberDefaultInfoReqDto.java
@@ -1,0 +1,22 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import com.ssafy.ssafsound.domain.member.validator.Semester;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PatchMemberDefaultInfoReqDto {
+
+    @NotNull
+    private Boolean ssafyMember;
+
+    @Semester
+    private Integer semester;
+
+    private String campus;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
@@ -29,4 +29,8 @@ public class PostMemberInfoReqDto {
     private Boolean isMajor;
 
     private String campus;
+
+    public boolean isNotSemesterPresent() {
+        return this.semester == null;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
@@ -11,7 +11,8 @@ public enum MemberErrorInfo {
     MEMBER_OAUTH_NOT_FOUND("709", "소셜 로그인에 문제가 발생했습니다."),
     MEMBER_INFORMATION_ERROR("710", "멤버 정보 조회에서 문제가 발생했습니다."),
     MEMBER_NICKNAME_DUPLICATION("711", "중복되는 닉네임입니다."),
-    MEMBER_CERTIFICATED_FAIL("712", "인증 시도 가능 횟수를 초과하여 일정 시간이 자나야 재시도 할 수 있습니다.");
+    MEMBER_CERTIFICATED_FAIL("712", "인증 시도 가능 횟수를 초과하여 일정 시간이 자나야 재시도 할 수 있습니다."),
+    SEMESTER_NOT_FOUND("713", "SSAFY Member 등록 또는 기수 수정 시, 기수 값은 필수입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberConstantProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberConstantProvider.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafsound.domain.member.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "spring.constant.certification")
+@ConstructorBinding
+public class MemberConstantProvider {
+    private final Integer MAX_MINUTES;
+    private final Integer CERTIFICATION_INQUIRY_TIME;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -110,6 +110,17 @@ public class MemberService {
         deleteExistMemberSkillsAllByMemberAndSaveNewRequest(member, putMemberProfileReqDto.getSkills());
     }
 
+    /**
+     *  Member의 기본 정보 수정을 한다.
+     * @author : YongsHub
+     * @param : PatchMemberDefaultInfoReqDto : ssafyMember가 true라면 기수정보와 캠퍼스 정보가 필수임
+     * @param : PatchMemberDefaultInfoReqDto :ssafyMember가 false라면 기수정보와 캠퍼스 정보가 필요하지 않음
+     * @return : void
+     * @see : CargoShip#getRemainingCapacity()용량 확인하는 함수
+     * @throws : ssafyMember가 true인데 semester가 null일 경우 SEMESTER_NOT_FOUND Exception,
+     * @throws : memberId를 찾을 수 없을때 MEMBER_NOT_FOUND_BY_ID Exception
+     * @see : CargoShip#unload() 제품을 내리는 함수
+     */
     @Transactional
     public void patchMemberDefaultInfo(
             Long memberId,
@@ -117,9 +128,6 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
-        if(patchMemberDefaultInfoReqDto.getSemester() == null) {
-            throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
-        }
         member.exchangeDefaultInformation(patchMemberDefaultInfoReqDto, metaDataConsumer);
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -112,11 +112,14 @@ public class MemberService {
 
     @Transactional
     public void patchMemberDefaultInfo(
-            AuthenticatedMember authenticatedMember,
+            Long memberId,
             PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
-        Member member = memberRepository.findById(authenticatedMember.getMemberId())
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
+        if(patchMemberDefaultInfoReqDto.getSemester() == null) {
+            throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
+        }
         member.exchangeDefaultInformation(patchMemberDefaultInfoReqDto, metaDataConsumer);
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -10,7 +10,6 @@ import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,10 +29,7 @@ public class MemberService {
     private final MemberSkillRepository memberSkillRepository;
     private final MemberLinkRepository memberLinkRepository;
     private final MetaDataConsumer metaDataConsumer;
-    @Value("${spring.constant.certification.CERTIFICATION_INQUIRY_TIME}")
-    private Integer MAX_CERTIFICATION_INQUIRY_COUNT;
-    @Value("${spring.constant.certification.MAX_MINUTES}")
-    private Integer MAX_MINUTES;
+    private final MemberConstantProvider memberConstantProvider;
 
     @Transactional
     public AuthenticatedMember createMemberByOauthIdentifier(PostMemberReqDto postMemberReqDto) {
@@ -89,8 +85,12 @@ public class MemberService {
         Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
         long minutes = getMinutesByDifferenceCertificationTryTime(member.getCertificationTryTime());
-        if(minutes > MAX_MINUTES) member.initializeCertificationInquiryCount();
-        if(member.getCertificationInquiryCount() >= MAX_CERTIFICATION_INQUIRY_COUNT) throw new MemberException(MemberErrorInfo.MEMBER_CERTIFICATED_FAIL);
+        if(minutes > memberConstantProvider.getMAX_MINUTES()) {
+            member.initializeCertificationInquiryCount();
+        }
+        if(member.getCertificationInquiryCount() >= memberConstantProvider.getCERTIFICATION_INQUIRY_TIME()) {
+            throw new MemberException(MemberErrorInfo.MEMBER_CERTIFICATED_FAIL);
+        }
 
         if (isValidCertification(postCertificationInfoReqDto)) {
             member.setCertificationState(AuthenticationStatus.CERTIFIED);

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -113,6 +113,16 @@ public class MemberService {
         deleteExistMemberSkillsAllByMemberAndSaveNewRequest(member, putMemberProfileReqDto.getSkills());
     }
 
+    @Transactional
+    public void patchMemberDefaultInfo(
+            AuthenticatedMember authenticatedMember,
+            PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
+        Member member = memberRepository.findById(authenticatedMember.getMemberId())
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        member.exchangeDefaultInformation(patchMemberDefaultInfoReqDto, metaDataConsumer);
+    }
+
     @Transactional(readOnly = true)
     public MemberRole findMemberRoleByRoleName(String roleType) {
         return memberRoleRepository.findByRoleType(roleType).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_ROLE_TYPE_NOT_FOUND));

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -75,16 +75,13 @@ public class MemberService {
     @Transactional
     public GetMemberResDto registerMemberInformation(AuthenticatedMember authenticatedMember, PostMemberInfoReqDto postMemberInfoReqDto) {
         boolean existNickname = memberRepository.existsByNickname(postMemberInfoReqDto.getNickname());
+
         if(existNickname) throw new MemberException(MemberErrorInfo.MEMBER_NICKNAME_DUPLICATION);
-        Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
-        MemberRole memberRole = member.getRole();
-        if (postMemberInfoReqDto.getSsafyMember()) {
-            member.setSSAFYMemberInformation(postMemberInfoReqDto, metaDataConsumer);
-            return GetMemberResDto.fromSSAFYUser(member, memberRole);
-        } else {
-            member.setGeneralMemberInformation(postMemberInfoReqDto);
-            return GetMemberResDto.fromGeneralUser(member, memberRole);
-        }
+
+        Member member = memberRepository.findById(authenticatedMember.getMemberId())
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        return member.registerMemberInformation(postMemberInfoReqDto, metaDataConsumer);
     }
 
     @Transactional
@@ -130,15 +127,15 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public GetMemberResDto getMemberInformation(AuthenticatedMember authenticatedMember) {
-        Member member = memberRepository.findById(authenticatedMember.getMemberId()).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
-        MemberRole memberRole = member.getRole();
+        Member member = memberRepository.findById(authenticatedMember.getMemberId())
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
         if (isNotInputMemberInformation(member)) {
-            return GetMemberResDto.fromGeneralUser(member, memberRole);
+            return GetMemberResDto.fromGeneralUser(member);
         } else if(isGeneralMemberInformation(member)){
-            return GetMemberResDto.fromGeneralUser(member, memberRole);
+            return GetMemberResDto.fromGeneralUser(member);
         } else if (isSSAFYMemberInformation(member)) {
-            return GetMemberResDto.fromSSAFYUser(member, memberRole);
+            return GetMemberResDto.fromSSAFYUser(member);
         }
         throw new MemberException(MemberErrorInfo.MEMBER_INFORMATION_ERROR);
     }

--- a/src/main/java/com/ssafy/ssafsound/global/config/MagicNumberConfig.java
+++ b/src/main/java/com/ssafy/ssafsound/global/config/MagicNumberConfig.java
@@ -1,0 +1,12 @@
+package com.ssafy.ssafsound.global.config;
+
+import com.ssafy.ssafsound.domain.member.service.MemberConstantProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({MemberConstantProvider.class})
+@RequiredArgsConstructor
+public class MagicNumberConfig {
+}

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -367,11 +367,15 @@ class MemberServiceTest {
                 .answer(answer)
                 .build();
 
-        given(metaDataConsumer.getMetaData(MetaDataType.MAJOR_TRACK.name(), majorTrack)).willReturn(new MetaData(MajorTrack.JAVA));
-        given(metaDataConsumer.getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer())).willReturn(new MetaData(Certification.valueOf(name)));
-        given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
+        given(metaDataConsumer.getMetaData(MetaDataType.MAJOR_TRACK.name(), majorTrack))
+                .willReturn(new MetaData(MajorTrack.JAVA));
+        given(metaDataConsumer.getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer()))
+                .willReturn(new MetaData(Certification.valueOf(name)));
+        given(memberRepository.findById(authenticatedMember.getMemberId()))
+                .willReturn(Optional.of(member));
 
-        PostCertificationInfoResDto postCertificationInfoResDto = memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto);
+        PostCertificationInfoResDto postCertificationInfoResDto = memberService
+                .certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto);
 
         assertThat(member.getCertificationState()).isEqualTo(AuthenticationStatus.CERTIFIED);
         assertThat(member.getMajorTrack().getName()).isEqualTo(majorTrack);
@@ -392,12 +396,15 @@ class MemberServiceTest {
                 .semester(semester)
                 .answer(answer)
                 .build();
+        given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
+        given(metaDataConsumer.getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer().toLowerCase()))
+                .willReturn(new MetaData(Certification.valueOf(name)));
 
-        given(metaDataConsumer.getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer())).willReturn(new MetaData(Certification.valueOf(name)));
+        PostCertificationInfoResDto postCertificationInfoResDto = memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto);
 
-        assertThrows(MemberException.class, () -> memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto));
+        assertThat(postCertificationInfoResDto.isPossible()).isFalse();
 
-        verify(metaDataConsumer).getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer());
+        verify(metaDataConsumer).getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer().toLowerCase());
     }
 
 
@@ -409,12 +416,10 @@ class MemberServiceTest {
                 .answer("선물")
                 .build();
 
-        given(metaDataConsumer.getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer())).willReturn(new MetaData(Certification.ONE_SEMESTER));
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.empty());
 
         assertThrows(MemberException.class, () -> memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto));
 
-        verify(metaDataConsumer).getMetaData(MetaDataType.CERTIFICATION.name(), postCertificationInfoReqDto.getAnswer());
         verify(memberRepository).findById(authenticatedMember.getMemberId());
     }
 }


### PR DESCRIPTION
## Issues

- #156 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 이 비즈니스 로직의 핵심은 member의 기본 정보인 ssafyMember (true or false): 싸피멤버인지 아닌지 , semester (1,2, 3 .... 9) : 기수 정보, majorTrack(Embedded, Java, Python ... ) 등 전공 정보를 변경하는 일을 합니다.

따라서, member라는 entity가 할 수 있는 책임이라고 생각해서
```Java
@Transactional
    public void patchMemberDefaultInfo(
            AuthenticatedMember authenticatedMember,
            PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
        
        Member member = memberRepository.findById(authenticatedMember.getMemberId())
                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));

        member.exchangeDefaultInformation(patchMemberDefaultInfoReqDto, metaDataConsumer);
    }
```
exchangeDefaultInformation 메서드를 통해 일을 수행하고 있습니다.

exchangeDefaultInformation의 내부 로직이 서비스 메서드 내에 노출되는 것이 좋은지 함께 의견을 내주시면 감사할 것 같습니다.

---

ssafyMember: true 일 경우, 기수정보가 null로 Request된다면 NullPointException이 발생하는 치명적인 상황을 발견했습니다.
(그 이유는 semester는 ssafyMember가 fasle로 request됐을때, null을 허용했었기 때문입니다)
따라서, member의 기본정보 수정 API에서
해당 사항을 수정하여 Validation을 추가했습니다.

```Java
if(postMemberInfoReqDto.isNotSemesterPresent()) {
        throw new MemberException(MemberErrorInfo.SEMESTER_NOT_FOUND);
}
```

전공트랙에 대한 검증은 MetaDataConsumer가 진행하고 있었습니다.

---
@Value Annotation을 사용한 MAGIC NUMBER의 강한 결합도 문제!

MemberService의 일부 테스트가 실패했던 이유는 @Value애노테이션을 통해 멤버 서비스에서 Magic Number를 Runtime때 가져왔기 때문에 테스트 코드에서 값을 가져올 수 없는 치명적인 상황이 있었습니다.

이를 해결하기 위해 ScrapConfig와 같이 MagicNumberConfig를 통해 MemberConstantProvider를 사용했습니다.

이와 관련된 테스트 코드 수정이 존재합니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
