### PR TITLE
refactor: 리크루트 수정 

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/RecruitLimitation.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/domain/RecruitLimitation.java
@@ -37,4 +37,7 @@ public class RecruitLimitation {
     public void increaseCurrentNumber() {
         this.currentNumber++;
     }
+    public void setCurrentNumber(Integer currentNumber) {
+        this.currentNumber = currentNumber;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitLimitationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitLimitationRepository.java
@@ -3,8 +3,6 @@ package com.ssafy.ssafsound.domain.recruit.repository;
 import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
 import com.ssafy.ssafsound.domain.recruit.domain.RecruitLimitation;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -12,7 +10,5 @@ import java.util.List;
 public interface RecruitLimitationRepository extends JpaRepository<RecruitLimitation, Long> {
     List<RecruitLimitation> findByRecruitId(Long recruitId);
 
-    @Modifying
-    @Query("DELETE FROM  recruit_limitation rl WHERE rl.recruit = :recruit")
     void deleteAllByRecruit(@Param("recruit") Recruit recruit);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitSkillRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitSkillRepository.java
@@ -1,18 +1,14 @@
 package com.ssafy.ssafsound.domain.recruit.repository;
 
 import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
-import com.ssafy.ssafsound.domain.recruit.domain.RecruitLimitation;
+import com.ssafy.ssafsound.domain.recruit.domain.RecruitSkill;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
-public interface RecruitLimitationRepository extends JpaRepository<RecruitLimitation, Long> {
-    List<RecruitLimitation> findByRecruitId(Long recruitId);
-
+public interface RecruitSkillRepository extends JpaRepository<RecruitSkill, Long> {
     @Modifying
-    @Query("DELETE FROM  recruit_limitation rl WHERE rl.recruit = :recruit")
+    @Query("DELETE FROM  recruit_skill rs WHERE rs.recruit = :recruit")
     void deleteAllByRecruit(@Param("recruit") Recruit recruit);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
@@ -107,7 +107,7 @@ public class RecruitService {
                 .map(RecruitLimitation::getType)
                 .collect(Collectors.toList());
 
-        recruitApplicationRepository.deletNotIncludeRecruitTypes(recruitTypes);
+        recruitApplicationRepository.deleteByTypeNotIn(recruitTypes);
     }
 
     @Transactional

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -1,5 +1,6 @@
 package com.ssafy.ssafsound.domain.recruitapplication.repository;
 
+import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
@@ -39,4 +40,8 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
 
     @Query("SELECT ra FROM recruit_application ra join fetch ra.recruit as r join fetch ra.member where r.id in (:recruitId) and ra.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.DONE")
     List<RecruitApplication> findDoneRecruitApplicationByRecruitIdInFetchRecruitAndMember(List<Long> recruitId);
+
+    List<RecruitApplication> findByRecruitIdAndMatchStatus(Long recruitId, MatchStatus matchStatus);
+
+    void deletNotIncludeRecruitTypes(List<MetaData> recruitTypes);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -43,5 +43,5 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
 
     List<RecruitApplication> findByRecruitIdAndMatchStatus(Long recruitId, MatchStatus matchStatus);
 
-    void deletNotIncludeRecruitTypes(List<MetaData> recruitTypes);
+    void deleteByTypeNotIn(List<MetaData> recruitTypes);
 }


### PR DESCRIPTION
## Issues

- #136

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
리크루트 모집 인원 수정 기능 변경

- 기존
리크루트 모집 인원제한은 수정 시, 증가만 가능하며, 모집파트 또한 추가만 가능하다.

변경
```
리크루트 모집 인원은 제한은, 해당 파트에 모집 완료된 인원 아래로는 수정할 수 없지만, 그 외의 감소와 증가는 모두 가능하다.
리크루트 모집파트는 삭제 또는 추가가 가능하다. 단 해당 파트에 모집완료 인원이 존재하는 경우 삭제할 수 없다.
리크루트 모집파트를 삭제하는 경우, 연관된 리크루트 모집신청은 모두 삭제되어야한다.
```

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
