### PR TITLE
feat : 채팅방 삭제 api 추가

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/chat/controller/ChatController.java
@@ -36,4 +36,14 @@ public class ChatController {
                 .build();
     }
 
+    @DeleteMapping("/{chatRoomId}")
+    public EnvelopeResponse<DeleteChatResDto> deleteChatRoom(@Authentication AuthenticatedMember member,
+                                                             @PathVariable Long chatRoomId) {
+
+        return EnvelopeResponse.<DeleteChatResDto>builder()
+                .data(chatRoomService.deleteChatRoom(member.getMemberId(), chatRoomId))
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/chat/domain/Talker.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/chat/domain/Talker.java
@@ -34,4 +34,8 @@ public class Talker {
 
     @Column
     private LocalDateTime readAt;
+
+    public void setStartedAt(LocalDateTime inputTime) {
+        this.startedAt = inputTime;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/chat/dto/DeleteChatResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/chat/dto/DeleteChatResDto.java
@@ -1,4 +1,11 @@
 package com.ssafy.ssafsound.domain.chat.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class DeleteChatResDto {
+
+    private Long id;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/chat/exception/ChatErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/chat/exception/ChatErrorInfo.java
@@ -1,4 +1,19 @@
 package com.ssafy.ssafsound.domain.chat.exception;
 
+import lombok.Getter;
+
+@Getter
 public enum ChatErrorInfo {
+
+    INVALID_CHAT_ROOM_ID("1001","유효하지 않은 데이터입니다."),
+    UNAUTHORIZED_MEMBER("1002","삭제 권한이 없는 사용자입니다."),
+    INACTIVE_CHAT_ROOM("1003","채팅이 불가능한 채팅방입니다.");
+
+    private String code;
+    private String message;
+
+    ChatErrorInfo(String code, String message){
+        this.code = code;
+        this.message = message;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/chat/exception/ChatException.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/chat/exception/ChatException.java
@@ -1,5 +1,10 @@
 package com.ssafy.ssafsound.domain.chat.exception;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class ChatException extends RuntimeException {
 
     private ChatErrorInfo info;

--- a/src/main/java/com/ssafy/ssafsound/domain/chat/repository/TalkerRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/chat/repository/TalkerRepository.java
@@ -6,10 +6,13 @@ import com.ssafy.ssafsound.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TalkerRepository extends JpaRepository<Talker, Long> {
     List<Talker> findAllByMember(Member member);
 
 
     Talker findByChatRoomAndIdNot(ChatRoom chatRoom, Long id);
+
+    Optional<Talker> findByChatRoomAndMember(ChatRoom chatRoom, Member member);
 }


### PR DESCRIPTION
- 채팅 삭제 api 및 에러코드 추가

## Issues

- #103 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
- 채팅방 삭제는 ChatRoom을 삭제하는 것이 아닌 Talker의 startedAt 필드를 최신화 하는 형태로 soft delete 됩니다. 삭제를 하지 않는 채팅상대의 경우 영향이 없어야하기 때문입니다. 따라서 유저는 채팅방 내부 메세지를 조회할 때 자신의 startedAt의 시간 이후의 메시지만 조회가 가능합니다.