### PR TITLE
feat: 목록 조회 관련 기능 커서 기반으로 페이징 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	id 'jacoco'
+	// querydsl 플러그인 추가
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.ssafy'
@@ -92,6 +94,9 @@ repositories {
 
 ext {
 	set('snippetsDir', file("build/generated-snippets"))
+
+	// QueryDsl Version
+	queryDslVersion = "5.0.0"
 }
 
 dependencies {
@@ -124,6 +129,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// querydsl 의존성 추가
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
@@ -133,4 +142,33 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	dependsOn test
+}
+
+
+// querydsl 사용할 경로 지정
+def querydslDir = "build/generated"
+
+// JPA 사용여부 및 사용 경로 설정
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+// build시 사용할 sourceSet 추가 설정
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+
+// querydsl 컴파일 시 사용할 옵션 설정
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+
+// querydsl이 compileClassPath를 상속하도록 설정
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -87,9 +87,9 @@ public class PostController {
     }
 
     @GetMapping("/hot")
-    public EnvelopeResponse<GetPostHotResDto> findHotPosts(Pageable pageable) {
+    public EnvelopeResponse<GetPostHotResDto> findHotPosts(@Valid GetPostHotReqDto getPostHotReqDto) {
         return EnvelopeResponse.<GetPostHotResDto>builder()
-                .data(postService.findHotPosts(pageable))
+                .data(postService.findHotPosts(getPostHotReqDto.getCursor(), getPostHotReqDto.getSize()))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -25,9 +25,9 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public EnvelopeResponse<GetPostResDto> findPosts(@RequestParam Long boardId, Pageable pageable) {
+    public EnvelopeResponse<GetPostResDto> findPosts(@Valid GetPostReqDto getPostReqDto) {
         return EnvelopeResponse.<GetPostResDto>builder()
-                .data(postService.findPosts(boardId, pageable))
+                .data(postService.findPosts(getPostReqDto.getBoardId(), getPostReqDto.getCursor(), getPostReqDto.getSize()))
                 .build();
     }
 
@@ -110,7 +110,7 @@ public class PostController {
     @GetMapping("/hot/search")
     public EnvelopeResponse<GetPostHotResDto> searchHotPosts(@Valid GetPostHotSearchReqDto getPostHotSearchReqDto) {
         return EnvelopeResponse.<GetPostHotResDto>builder()
-                .data(postService.searchHotPosts(getPostHotSearchReqDto.getKeyword(), getPostHotSearchReqDto.getCursor(), getPostHotSearchReqDto. getSize()))
+                .data(postService.searchHotPosts(getPostHotSearchReqDto.getKeyword(), getPostHotSearchReqDto.getCursor(), getPostHotSearchReqDto.getSize()))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -101,9 +101,10 @@ public class PostController {
     }
 
     @GetMapping("/search")
-    public EnvelopeResponse<GetPostResDto> searchPosts(@Valid GetPostSearchReqDto getPostSearchReqDto, Pageable pageable) {
+    public EnvelopeResponse<GetPostResDto> searchPosts(@Valid GetPostSearchReqDto getPostSearchReqDto) {
         return EnvelopeResponse.<GetPostResDto>builder()
-                .data(postService.searchPosts(getPostSearchReqDto.getBoardId(), getPostSearchReqDto.getKeyword(), pageable))
+                .data(postService.searchPosts(getPostSearchReqDto.getBoardId(), getPostSearchReqDto.getKeyword(),
+                        getPostSearchReqDto.getCursor(), getPostSearchReqDto.getSize()))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -11,7 +11,6 @@ import com.ssafy.ssafsound.domain.post.service.PostService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -108,9 +108,9 @@ public class PostController {
     }
 
     @GetMapping("/hot/search")
-    public EnvelopeResponse<GetPostHotResDto> searchHotPosts(@Valid GetPostHotSearchReqDto getPostHotSearchReqDto, Pageable pageable) {
+    public EnvelopeResponse<GetPostHotResDto> searchHotPosts(@Valid GetPostHotSearchReqDto getPostHotSearchReqDto) {
         return EnvelopeResponse.<GetPostHotResDto>builder()
-                .data(postService.searchHotPosts(getPostHotSearchReqDto.getKeyword(), pageable))
+                .data(postService.searchHotPosts(getPostHotSearchReqDto.getKeyword(), getPostHotSearchReqDto.getCursor(), getPostHotSearchReqDto. getSize()))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -26,7 +26,7 @@ public class PostController {
     @GetMapping
     public EnvelopeResponse<GetPostResDto> findPosts(@Valid GetPostReqDto getPostReqDto) {
         return EnvelopeResponse.<GetPostResDto>builder()
-                .data(postService.findPosts(getPostReqDto.getBoardId(), getPostReqDto.getCursor(), getPostReqDto.getSize()))
+                .data(postService.findPosts(getPostReqDto))
                 .build();
     }
 
@@ -58,7 +58,7 @@ public class PostController {
                                              @Valid @RequestBody PostPostReportReqDto postPostReportReqDto,
                                              @Authentication AuthenticatedMember loginMember) {
         return EnvelopeResponse.<Long>builder()
-                .data(postService.reportPost(postId, loginMember.getMemberId(), postPostReportReqDto.getContent()))
+                .data(postService.reportPost(postId, loginMember.getMemberId(), postPostReportReqDto))
                 .build();
     }
 
@@ -88,29 +88,28 @@ public class PostController {
     @GetMapping("/hot")
     public EnvelopeResponse<GetPostHotResDto> findHotPosts(@Valid GetPostHotReqDto getPostHotReqDto) {
         return EnvelopeResponse.<GetPostHotResDto>builder()
-                .data(postService.findHotPosts(getPostHotReqDto.getCursor(), getPostHotReqDto.getSize()))
+                .data(postService.findHotPosts(getPostHotReqDto))
                 .build();
     }
 
     @GetMapping("/my")
     public EnvelopeResponse<GetPostMyResDto> findMyPosts(GetPostMyReqDto getPostMyReqDto, @Authentication AuthenticatedMember loginMember) {
         return EnvelopeResponse.<GetPostMyResDto>builder()
-                .data(postService.findMyPosts(getPostMyReqDto.getCursor(), getPostMyReqDto.getSize(), loginMember.getMemberId()))
+                .data(postService.findMyPosts(getPostMyReqDto, loginMember.getMemberId()))
                 .build();
     }
 
     @GetMapping("/search")
     public EnvelopeResponse<GetPostResDto> searchPosts(@Valid GetPostSearchReqDto getPostSearchReqDto) {
         return EnvelopeResponse.<GetPostResDto>builder()
-                .data(postService.searchPosts(getPostSearchReqDto.getBoardId(), getPostSearchReqDto.getKeyword(),
-                        getPostSearchReqDto.getCursor(), getPostSearchReqDto.getSize()))
+                .data(postService.searchPosts(getPostSearchReqDto))
                 .build();
     }
 
     @GetMapping("/hot/search")
     public EnvelopeResponse<GetPostHotResDto> searchHotPosts(@Valid GetPostHotSearchReqDto getPostHotSearchReqDto) {
         return EnvelopeResponse.<GetPostHotResDto>builder()
-                .data(postService.searchHotPosts(getPostHotSearchReqDto.getKeyword(), getPostHotSearchReqDto.getCursor(), getPostHotSearchReqDto.getSize()))
+                .data(postService.searchHotPosts(getPostHotSearchReqDto))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/controller/PostController.java
@@ -94,9 +94,9 @@ public class PostController {
     }
 
     @GetMapping("/my")
-    public EnvelopeResponse<GetPostMyResDto> findMyPosts(Pageable pageable, @Authentication AuthenticatedMember loginMember) {
+    public EnvelopeResponse<GetPostMyResDto> findMyPosts(GetPostMyReqDto getPostMyReqDto, @Authentication AuthenticatedMember loginMember) {
         return EnvelopeResponse.<GetPostMyResDto>builder()
-                .data(postService.findMyPosts(pageable, loginMember.getMemberId()))
+                .data(postService.findMyPosts(getPostMyReqDto.getCursor(), getPostMyReqDto.getSize(), loginMember.getMemberId()))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostElement.java
@@ -17,7 +17,6 @@ public class GetPostElement {
     private int likeCount;
     private int commentCount;
     private LocalDateTime createAt;
-    private Long memberId;
     private String nickname;
     private Boolean anonymous;
     private String thumbnail;
@@ -33,7 +32,6 @@ public class GetPostElement {
                 .likeCount(post.getLikes().size())
                 .commentCount(post.getComments().size())
                 .createAt(post.getCreatedAt())
-                .memberId(anonymous ? -1 : post.getMember().getId())
                 .nickname(anonymous ? "익명" : post.getMember().getNickname())
                 .anonymous(anonymous)
                 .thumbnail(thumbnail)

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotElement.java
@@ -18,7 +18,6 @@ public class GetPostHotElement {
     private int likeCount;
     private int commentCount;
     private LocalDateTime createAt;
-    private Long memberId;
     private String nickname;
     private Boolean anonymous;
     private String thumbnail;
@@ -35,7 +34,6 @@ public class GetPostHotElement {
                 .likeCount(post.getLikes().size())
                 .commentCount(post.getComments().size())
                 .createAt(post.getCreatedAt())
-                .memberId(anonymous ? -1 : post.getMember().getId())
                 .nickname(anonymous ? "익명" : post.getMember().getNickname())
                 .anonymous(anonymous)
                 .thumbnail(thumbnail)

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotReqDto.java
@@ -3,13 +3,13 @@ package com.ssafy.ssafsound.domain.post.dto;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.Size;
+import javax.validation.constraints.Min;
 
 @Getter
 @Setter
 public class GetPostHotReqDto {
-    private int cursor;
+    private Long cursor;
 
-    @Size(min = 10)
+    @Min(value = 10, message = "Size가 너무 작습니다.")
     private int size;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotReqDto.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafsound.domain.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+public class GetPostHotReqDto {
+    private int cursor;
+
+    @Size(min = 10)
+    private int size;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
@@ -3,7 +3,6 @@ package com.ssafy.ssafsound.domain.post.dto;
 import com.ssafy.ssafsound.domain.post.domain.HotPost;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
@@ -13,7 +13,7 @@ public class GetPostHotResDto {
     private List<GetPostHotElement> posts;
     private Long cursor;
 
-    public static GetPostHotResDto from(List<HotPost> hotPosts, int size) {
+    public static GetPostHotResDto of(List<HotPost> hotPosts, int size) {
         Long nextCursor = null;
         if (hotPosts.size() > size) {
             hotPosts = hotPosts.subList(0, hotPosts.size() - 1);
@@ -21,8 +21,7 @@ public class GetPostHotResDto {
         }
 
         return GetPostHotResDto.builder()
-                .posts(hotPosts
-                        .stream()
+                .posts(hotPosts.stream()
                         .map(GetPostHotElement::from)
                         .collect(Collectors.toList()))
                 .cursor(nextCursor)

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
@@ -15,9 +15,10 @@ public class GetPostHotResDto {
 
     public static GetPostHotResDto of(List<HotPost> hotPosts, int size) {
         Long nextCursor = null;
-        if (hotPosts.size() > size) {
-            hotPosts = hotPosts.subList(0, hotPosts.size() - 1);
-            nextCursor = hotPosts.get(hotPosts.size() - 1).getId();
+        int pageSize = hotPosts.size() - 1;
+        if (pageSize >= size) {
+            hotPosts = hotPosts.subList(0, pageSize);
+            nextCursor = hotPosts.get(pageSize).getId();
         }
 
         return GetPostHotResDto.builder()

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotResDto.java
@@ -3,6 +3,7 @@ package com.ssafy.ssafsound.domain.post.dto;
 import com.ssafy.ssafsound.domain.post.domain.HotPost;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,13 +12,21 @@ import java.util.stream.Collectors;
 @Builder
 public class GetPostHotResDto {
     private List<GetPostHotElement> posts;
+    private Long cursor;
 
-    public static GetPostHotResDto from(List<HotPost> hotPosts) {
+    public static GetPostHotResDto from(List<HotPost> hotPosts, int size) {
+        Long nextCursor = null;
+        if (hotPosts.size() > size) {
+            hotPosts = hotPosts.subList(0, hotPosts.size() - 1);
+            nextCursor = hotPosts.get(hotPosts.size() - 1).getId();
+        }
+
         return GetPostHotResDto.builder()
                 .posts(hotPosts
                         .stream()
                         .map(GetPostHotElement::from)
                         .collect(Collectors.toList()))
+                .cursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotSearchReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotSearchReqDto.java
@@ -4,12 +4,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 @Getter
 @Setter
 public class GetPostHotSearchReqDto {
     @Size(min = 2)
+    @NotBlank
     private String keyword;
 
     private Long cursor;

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotSearchReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostHotSearchReqDto.java
@@ -3,6 +3,7 @@ package com.ssafy.ssafsound.domain.post.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 
 @Getter
@@ -10,4 +11,9 @@ import javax.validation.constraints.Size;
 public class GetPostHotSearchReqDto {
     @Size(min = 2)
     private String keyword;
+
+    private Long cursor;
+
+    @Min(value = 10, message = "Size가 너무 작습니다.")
+    private int size;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyElement.java
@@ -16,7 +16,6 @@ public class GetPostMyElement {
     private int likeCount;
     private int commentCount;
     private LocalDateTime createAt;
-    private Long memberId;
     private String nickname;
     private Boolean anonymous;
     private String thumbnail;
@@ -32,7 +31,6 @@ public class GetPostMyElement {
                 .likeCount(post.getLikes().size())
                 .commentCount(post.getComments().size())
                 .createAt(post.getCreatedAt())
-                .memberId(anonymous ? -1 : post.getMember().getId())
                 .nickname(anonymous ? "익명" : post.getMember().getNickname())
                 .anonymous(anonymous)
                 .thumbnail(thumbnail)

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyReqDto.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafsound.domain.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Min;
+
+@Getter
+@Setter
+public class GetPostMyReqDto {
+    private Long cursor;
+
+    @Min(value = 10, message = "Size가 너무 작습니다.")
+    private int size;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyResDto.java
@@ -15,9 +15,10 @@ public class GetPostMyResDto {
 
     public static GetPostMyResDto of(List<Post> posts, int size) {
         Long nextCursor = null;
-        if (posts.size() > size) {
-            posts = posts.subList(0, posts.size() - 1);
-            nextCursor = posts.get(posts.size() - 1).getId();
+        int pageSize = posts.size() - 1;
+        if (pageSize >= size) {
+            posts = posts.subList(0, pageSize);
+            nextCursor = posts.get(pageSize).getId();
         }
 
         return GetPostMyResDto.builder()

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostMyResDto.java
@@ -11,12 +11,20 @@ import java.util.stream.Collectors;
 @Builder
 public class GetPostMyResDto {
     private List<GetPostMyElement> posts;
+    private Long cursor;
 
-    public static GetPostMyResDto from(List<Post> posts) {
+    public static GetPostMyResDto of(List<Post> posts, int size) {
+        Long nextCursor = null;
+        if (posts.size() > size) {
+            posts = posts.subList(0, posts.size() - 1);
+            nextCursor = posts.get(posts.size() - 1).getId();
+        }
+
         return GetPostMyResDto.builder()
                 .posts(posts.stream()
                         .map(GetPostMyElement::from)
                         .collect(Collectors.toList()))
+                .cursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostReqDto.java
@@ -1,0 +1,17 @@
+package com.ssafy.ssafsound.domain.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Min;
+
+@Getter
+@Setter
+public class GetPostReqDto {
+    private Long boardId;
+    private Long cursor;
+
+    @Min(value = 10, message = "Size가 너무 작습니다.")
+    private int size;
+
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostResDto.java
@@ -11,10 +11,20 @@ import java.util.stream.Collectors;
 @Builder
 public class GetPostResDto {
     private List<GetPostElement> posts;
+    private Long cursor;
 
-    public static GetPostResDto from(List<Post> posts) {
+    public static GetPostResDto of(List<Post> posts, int size) {
+        Long nextCursor = null;
+        if (posts.size() > size) {
+            posts = posts.subList(0, posts.size() - 1);
+            nextCursor = posts.get(posts.size() - 1).getId();
+        }
+
         return GetPostResDto.builder()
-                .posts(posts.stream().map(GetPostElement::from).collect(Collectors.toList()))
+                .posts(posts.stream()
+                        .map(GetPostElement::from)
+                        .collect(Collectors.toList()))
+                .cursor(nextCursor)
                 .build();
 
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostResDto.java
@@ -15,9 +15,10 @@ public class GetPostResDto {
 
     public static GetPostResDto of(List<Post> posts, int size) {
         Long nextCursor = null;
-        if (posts.size() > size) {
-            posts = posts.subList(0, posts.size() - 1);
-            nextCursor = posts.get(posts.size() - 1).getId();
+        int pageSize = posts.size() - 1;
+        if (pageSize >= size) {
+            posts = posts.subList(0, pageSize);
+            nextCursor = posts.get(pageSize).getId();
         }
 
         return GetPostResDto.builder()

--- a/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/dto/GetPostSearchReqDto.java
@@ -3,6 +3,7 @@ package com.ssafy.ssafsound.domain.post.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
@@ -14,4 +15,9 @@ public class GetPostSearchReqDto {
     @Size(min = 2)
     @NotBlank
     private String keyword;
+
+    private Long cursor;
+
+    @Min(value = 10, message = "Size가 너무 작습니다.")
+    private int size;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.post.repository;
+
+import com.ssafy.ssafsound.domain.post.domain.HotPost;
+
+import java.util.List;
+
+public interface HotPostCustomRepository {
+    List<HotPost> findWithDetailsFetch(int cursor, int size);
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepository.java
@@ -5,5 +5,5 @@ import com.ssafy.ssafsound.domain.post.domain.HotPost;
 import java.util.List;
 
 public interface HotPostCustomRepository {
-    List<HotPost> findWithDetailsFetch(int cursor, int size);
+    List<HotPost> findWithDetailsFetch(Long cursor, int size);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface HotPostCustomRepository {
     List<HotPost> findWithDetailsFetch(Long cursor, int size);
+
+    List<HotPost> findWithDetailsFetchByKeyword(String keyword, Long cursor, int size);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepositoryImpl.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.ssafy.ssafsound.domain.post.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssafy.ssafsound.domain.post.domain.HotPost;
+import com.ssafy.ssafsound.domain.post.domain.QHotPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.ssafy.ssafsound.domain.post.domain.QPost.post;
+import static com.ssafy.ssafsound.domain.board.domain.QBoard.board;
+import static com.ssafy.ssafsound.domain.member.domain.QMember.member;
+
+
+@Repository
+@RequiredArgsConstructor
+public class HotPostCustomRepositoryImpl implements HotPostCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<HotPost> findWithDetailsFetch(int cursor, int size) {
+        QHotPost hotPost = QHotPost.hotPost;
+
+        List<Tuple> tuples = jpaQueryFactory.select(hotPost, post, board, member)
+                .from(hotPost)
+                .innerJoin(hotPost.post, post).fetchJoin()
+                .innerJoin(post.board, board).fetchJoin()
+                .innerJoin(post.member, member).fetchJoin()
+                .where(checkCursor(cursor))
+                .limit(size + 1)
+                .orderBy(post.id.desc())
+                .fetch();
+
+        List<HotPost> hotPosts = tuples.stream()
+                .map(tuple -> tuple.get(hotPost))
+                .collect(Collectors.toList());
+
+        return hotPosts;
+    }
+
+    private BooleanExpression checkCursor(Integer cursor) {
+        return cursor != -1 ? post.id.lt(cursor) : null;
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepositoryImpl.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepositoryImpl.java
@@ -6,14 +6,13 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ssafy.ssafsound.domain.post.domain.HotPost;
-import com.ssafy.ssafsound.domain.post.domain.QHotPost;
-import com.ssafy.ssafsound.domain.post.domain.QPost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.ssafy.ssafsound.domain.post.domain.QHotPost.hotPost;
 import static com.ssafy.ssafsound.domain.post.domain.QPost.post;
 import static com.ssafy.ssafsound.domain.board.domain.QBoard.board;
 import static com.ssafy.ssafsound.domain.member.domain.QMember.member;
@@ -27,8 +26,6 @@ public class HotPostCustomRepositoryImpl implements HotPostCustomRepository {
 
     @Override
     public List<HotPost> findWithDetailsFetch(Long cursor, int size) {
-        QHotPost hotPost = QHotPost.hotPost;
-
         List<Tuple> tuples = jpaQueryFactory.select(hotPost, post, board, member)
                 .from(hotPost)
                 .innerJoin(hotPost.post, post).fetchJoin()
@@ -39,17 +36,13 @@ public class HotPostCustomRepositoryImpl implements HotPostCustomRepository {
                 .orderBy(post.id.desc())
                 .fetch();
 
-        List<HotPost> hotPosts = tuples.stream()
+        return tuples.stream()
                 .map(tuple -> tuple.get(hotPost))
                 .collect(Collectors.toList());
-
-        return hotPosts;
     }
 
     @Override
     public List<HotPost> findWithDetailsFetchByKeyword(String keyword, Long cursor, int size) {
-        QHotPost hotPost = QHotPost.hotPost;
-
         List<Tuple> tuples = jpaQueryFactory.select(hotPost, post, board, member)
                 .from(hotPost)
                 .innerJoin(hotPost.post, post).fetchJoin()
@@ -60,11 +53,9 @@ public class HotPostCustomRepositoryImpl implements HotPostCustomRepository {
                 .orderBy(post.id.desc())
                 .fetch();
 
-        List<HotPost> hotPosts = tuples.stream()
+        return tuples.stream()
                 .map(tuple -> tuple.get(hotPost))
                 .collect(Collectors.toList());
-
-        return hotPosts;
     }
 
     private BooleanExpression postIdLtCursor(Long cursor) {
@@ -72,8 +63,8 @@ public class HotPostCustomRepositoryImpl implements HotPostCustomRepository {
     }
 
     private BooleanExpression containTitleOrContent(String keyword) {
-        StringTemplate title = Expressions.stringTemplate("replace({0}, ' ', '')", QPost.post.title);
-        StringTemplate content = Expressions.stringTemplate("replace({0}, ' ', '')", QPost.post.content);
+        StringTemplate title = Expressions.stringTemplate("replace({0}, ' ', '')", post.title);
+        StringTemplate content = Expressions.stringTemplate("replace({0}, ' ', '')", post.content);
         return title.like("%" + keyword + "%").or(content.like("%" + keyword + "%"));
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepositoryImpl.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostCustomRepositoryImpl.java
@@ -23,7 +23,7 @@ public class HotPostCustomRepositoryImpl implements HotPostCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<HotPost> findWithDetailsFetch(int cursor, int size) {
+    public List<HotPost> findWithDetailsFetch(Long cursor, int size) {
         QHotPost hotPost = QHotPost.hotPost;
 
         List<Tuple> tuples = jpaQueryFactory.select(hotPost, post, board, member)
@@ -43,7 +43,7 @@ public class HotPostCustomRepositoryImpl implements HotPostCustomRepository {
         return hotPosts;
     }
 
-    private BooleanExpression checkCursor(Integer cursor) {
+    private BooleanExpression checkCursor(Long cursor) {
         return cursor != -1 ? post.id.lt(cursor) : null;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostRepository.java
@@ -1,14 +1,12 @@
 package com.ssafy.ssafsound.domain.post.repository;
 
 import com.ssafy.ssafsound.domain.post.domain.HotPost;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -25,12 +23,4 @@ public interface HotPostRepository extends JpaRepository<HotPost, Long>, HotPost
     void deleteHotPostsUnderThreshold(@Param("threshold") Long threshold);
 
     Optional<HotPost> findByPostId(Long postId);
-
-    @Query("SELECT h FROM hot_post h " +
-            "JOIN FETCH h.post p " +
-            "JOIN FETCH p.board b " +
-            "JOIN FETCH p.member " +
-            "WHERE (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') " +
-            "OR REPLACE(p.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) ")
-    List<HotPost> findWithDetailsFetchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/HotPostRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface HotPostRepository extends JpaRepository<HotPost, Long> {
+public interface HotPostRepository extends JpaRepository<HotPost, Long>, HotPostCustomRepository{
     @Modifying
     @Query("DELETE FROM hot_post h " +
             "WHERE h.id IN ( " +
@@ -23,12 +23,6 @@ public interface HotPostRepository extends JpaRepository<HotPost, Long> {
             "  HAVING COUNT(p.id) < :threshold " +
             ")")
     void deleteHotPostsUnderThreshold(@Param("threshold") Long threshold);
-
-    @Query("SELECT h FROM hot_post h " +
-            "JOIN FETCH h.post p " +
-            "JOIN FETCH p.board " +
-            "JOIN FETCH p.member ")
-    List<HotPost> findWithDetailsFetch(Pageable pageable);
 
     Optional<HotPost> findByPostId(Long postId);
 

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.post.repository;
+
+import com.ssafy.ssafsound.domain.post.domain.Post;
+
+import java.util.List;
+
+public interface PostCustomRepository {
+    List<Post> findWithDetailsByBoardId(Long boardId, Long cursor, int size);
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepository.java
@@ -8,4 +8,6 @@ public interface PostCustomRepository {
     List<Post> findWithDetailsByBoardId(Long boardId, Long cursor, int size);
 
     List<Post> findWithDetailsFetchByBoardIdAndKeyword(Long boardId, String keyword, Long cursor, int size);
+
+    List<Post> findWithDetailsByMemberId(Long memberId, Long cursor, int size);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface PostCustomRepository {
     List<Post> findWithDetailsByBoardId(Long boardId, Long cursor, int size);
+
+    List<Post> findWithDetailsFetchByBoardIdAndKeyword(Long boardId, String keyword, Long cursor, int size);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.ssafy.ssafsound.domain.post.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssafy.ssafsound.domain.post.domain.Post;
+import com.ssafy.ssafsound.domain.post.domain.QPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.ssafy.ssafsound.domain.board.domain.QBoard.board;
+import static com.ssafy.ssafsound.domain.member.domain.QMember.member;
+import static com.ssafy.ssafsound.domain.post.domain.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Post> findWithDetailsByBoardId(Long boardId, Long cursor, int size) {
+        QPost post = QPost.post;
+
+        List<Tuple> tuples = jpaQueryFactory.select(post, board, member)
+                .from(post)
+                .innerJoin(post.board, board).fetchJoin()
+                .innerJoin(post.member, member).fetchJoin()
+                .where(postIdLtCursor(cursor))
+                .limit(size + 1)
+                .orderBy(post.id.desc())
+                .fetch();
+
+        return tuples.stream()
+                .map(tuple -> tuple.get(post))
+                .collect(Collectors.toList());
+    }
+
+    private BooleanExpression postIdLtCursor(Long cursor) {
+        return cursor != -1 ? post.id.lt(cursor) : null;
+    }
+
+    private BooleanExpression containTitleOrContent(String keyword) {
+        StringTemplate title = Expressions.stringTemplate("replace({0}, ' ', '')", QPost.post.title);
+        StringTemplate content = Expressions.stringTemplate("replace({0}, ' ', '')", QPost.post.content);
+        return title.like("%" + keyword + "%").or(content.like("%" + keyword + "%"));
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostCustomRepositoryImpl.java
@@ -54,6 +54,22 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public List<Post> findWithDetailsByMemberId(Long memberId, Long cursor, int size) {
+        List<Tuple> tuples = jpaQueryFactory.select(post, board, member)
+                .from(post)
+                .innerJoin(post.board, board).fetchJoin()
+                .innerJoin(post.member, member).fetchJoin()
+                .where(postIdLtCursor(cursor), member.id.eq(memberId))
+                .limit(size + 1)
+                .orderBy(post.id.desc())
+                .fetch();
+
+        return tuples.stream()
+                .map(tuple -> tuple.get(post))
+                .collect(Collectors.toList());
+    }
+
     private BooleanExpression postIdLtCursor(Long cursor) {
         return cursor != -1 ? post.id.lt(cursor) : null;
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -12,9 +12,9 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
-    @EntityGraph(attributePaths = {"board", "member"})
-    List<Post> findWithDetailsByBoardId(@Param("boardId") Long boardId, Pageable pageable);
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository{
+//    @EntityGraph(attributePaths = {"board", "member"})
+//    List<Post> findWithDetailsByBoardId(@Param("boardId") Long boardId, Pageable pageable);
 
     boolean existsByIdAndMemberId(Long id, Long memberId);
 

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -1,21 +1,15 @@
 package com.ssafy.ssafsound.domain.post.repository;
 
 import com.ssafy.ssafsound.domain.post.domain.Post;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository{
-//    @EntityGraph(attributePaths = {"board", "member"})
-//    List<Post> findWithDetailsByBoardId(@Param("boardId") Long boardId, Pageable pageable);
-
     boolean existsByIdAndMemberId(Long id, Long memberId);
 
     @Query("SELECT p FROM post p JOIN FETCH p.member WHERE p.id = :id")
@@ -23,15 +17,4 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
 
     @Query("SELECT p FROM post p JOIN FETCH p.member LEFT JOIN FETCH p.images WHERE p.id = :id")
     Optional<Post> findWithMemberAndPostImageFetchById(@Param("id") Long id);
-
-    @EntityGraph(attributePaths = {"board", "member"})
-    List<Post> findWithDetailsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
-
-//    @Query("SELECT p FROM post p " +
-//            "JOIN FETCH p.board b " +
-//            "JOIN FETCH p.member " +
-//            "WHERE (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') " +
-//            "OR REPLACE(p.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) " +
-//            "AND b.id = :boardId ")
-//    List<Post> findWithDetailsFetchByBoardIdAndKeyword(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/repository/PostRepository.java
@@ -27,11 +27,11 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     @EntityGraph(attributePaths = {"board", "member"})
     List<Post> findWithDetailsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
-    @Query("SELECT p FROM post p " +
-            "JOIN FETCH p.board b " +
-            "JOIN FETCH p.member " +
-            "WHERE (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') " +
-            "OR REPLACE(p.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) " +
-            "AND b.id = :boardId ")
-    List<Post> findWithDetailsFetchByBoardIdAndKeyword(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
+//    @Query("SELECT p FROM post p " +
+//            "JOIN FETCH p.board b " +
+//            "JOIN FETCH p.member " +
+//            "WHERE (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') " +
+//            "OR REPLACE(p.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) " +
+//            "AND b.id = :boardId ")
+//    List<Post> findWithDetailsFetchByBoardIdAndKeyword(@Param("boardId") Long boardId, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -41,7 +41,11 @@ public class PostService {
     private final PostImageRepository postImageRepository;
 
     @Transactional(readOnly = true)
-    public GetPostResDto findPosts(Long boardId, Long cursor, int size) {
+    public GetPostResDto findPosts(GetPostReqDto getPostReqDto) {
+        Long boardId = getPostReqDto.getBoardId();
+        Long cursor = getPostReqDto.getCursor();
+        int size = getPostReqDto.getSize();
+
         if (!boardRepository.existsById(boardId)) {
             throw new BoardException(BoardErrorInfo.NO_BOARD);
         }
@@ -147,7 +151,9 @@ public class PostService {
     }
 
     @Transactional
-    public Long reportPost(Long postId, Long loginMemberId, String content) {
+    public Long reportPost(Long postId, Long loginMemberId, PostPostReportReqDto postPostReportReqDto) {
+        String content = postPostReportReqDto.getContent();
+
         Member loginMember = memberRepository.findById(loginMemberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
@@ -252,13 +258,19 @@ public class PostService {
 
 
     @Transactional(readOnly = true)
-    public GetPostHotResDto findHotPosts(Long cursor, int size) {
+    public GetPostHotResDto findHotPosts(GetPostHotReqDto getPostHotReqDto) {
+        Long cursor = getPostHotReqDto.getCursor();
+        int size = getPostHotReqDto.getSize();
+
         List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetch(cursor, size);
         return GetPostHotResDto.of(hotPosts, size);
     }
 
     @Transactional(readOnly = true)
-    public GetPostMyResDto findMyPosts(Long cursor, int size, Long loginMemberId) {
+    public GetPostMyResDto findMyPosts(GetPostMyReqDto getPostMyReqDto, Long loginMemberId) {
+        Long cursor = getPostMyReqDto.getCursor();
+        int size = getPostMyReqDto.getSize();
+
         Member loginMember = memberRepository.findById(loginMemberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
@@ -267,7 +279,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public GetPostResDto searchPosts(Long boardId, String keyword, Long cursor, int size) {
+    public GetPostResDto searchPosts(GetPostSearchReqDto getPostSearchReqDto) {
+        Long boardId = getPostSearchReqDto.getBoardId();
+        String keyword = getPostSearchReqDto.getKeyword();
+        Long cursor = getPostSearchReqDto.getCursor();
+        int size = getPostSearchReqDto.getSize();
+
         if (!boardRepository.existsById(boardId)) {
             throw new BoardException(BoardErrorInfo.NO_BOARD);
         }
@@ -277,7 +294,11 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public GetPostHotResDto searchHotPosts(String keyword, Long cursor, int size) {
+    public GetPostHotResDto searchHotPosts(GetPostHotSearchReqDto getPostHotSearchReqDto) {
+        String keyword = getPostHotSearchReqDto.getKeyword();
+        Long cursor = getPostHotSearchReqDto.getCursor();
+        int size = getPostHotSearchReqDto.getSize();
+
         List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetchByKeyword(keyword.replaceAll(" ", ""), cursor, size);
         return GetPostHotResDto.of(hotPosts, size);
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -18,10 +18,9 @@ import com.ssafy.ssafsound.domain.post.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 
 @Service
@@ -259,15 +258,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public GetPostMyResDto findMyPosts(Pageable pageable, Long loginMemberId) {
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-
+    public GetPostMyResDto findMyPosts(Long cursor, int size, Long loginMemberId) {
         Member loginMember = memberRepository.findById(loginMemberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
-        List<Post> posts = postRepository.findWithDetailsByMemberId(loginMember.getId(), pageRequest);
-
-        return GetPostMyResDto.from(posts);
+        List<Post> posts = postRepository.findWithDetailsByMemberId(loginMember.getId(), cursor, size);
+        return GetPostMyResDto.of(posts, size);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -255,11 +256,9 @@ public class PostService {
 
 
     @Transactional(readOnly = true)
-    public GetPostHotResDto findHotPosts(Pageable pageable) {
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetch(pageRequest);
-
-        return GetPostHotResDto.from(hotPosts);
+    public GetPostHotResDto findHotPosts(int cursor, int size) {
+        List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetch(cursor, size);
+        return GetPostHotResDto.from(hotPosts, size);
     }
 
     @Transactional(readOnly = true)
@@ -290,6 +289,6 @@ public class PostService {
     public GetPostHotResDto searchHotPosts(String keyword, Pageable pageable) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetchByKeyword(keyword.replaceAll(" ", ""), pageRequest);
-        return GetPostHotResDto.from(hotPosts);
+        return GetPostHotResDto.from(hotPosts, 10);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -43,15 +42,13 @@ public class PostService {
     private final PostImageRepository postImageRepository;
 
     @Transactional(readOnly = true)
-    public GetPostResDto findPosts(Long boardId, Pageable pageable) {
+    public GetPostResDto findPosts(Long boardId, Long cursor, int size) {
         if (!boardRepository.existsById(boardId)) {
             throw new BoardException(BoardErrorInfo.NO_BOARD);
         }
 
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<Post> posts = postRepository.findWithDetailsByBoardId(boardId, pageRequest);
-
-        return GetPostResDto.from(posts);
+        List<Post> posts = postRepository.findWithDetailsByBoardId(boardId, cursor, size);
+        return GetPostResDto.of(posts, size);
     }
 
     @Transactional(readOnly = true)
@@ -258,7 +255,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public GetPostHotResDto findHotPosts(Long cursor, int size) {
         List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetch(cursor, size);
-        return GetPostHotResDto.from(hotPosts, size);
+        return GetPostHotResDto.of(hotPosts, size);
     }
 
     @Transactional(readOnly = true)
@@ -282,12 +279,12 @@ public class PostService {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         List<Post> posts = postRepository.findWithDetailsFetchByBoardIdAndKeyword(boardId, keyword.replaceAll(" ", ""), pageRequest);
 
-        return GetPostResDto.from(posts);
+        return GetPostResDto.of(posts, 10);
     }
 
     @Transactional(readOnly = true)
     public GetPostHotResDto searchHotPosts(String keyword, Long cursor, int size) {
         List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetchByKeyword(keyword.replaceAll(" ", ""), cursor, size);
-        return GetPostHotResDto.from(hotPosts, size);
+        return GetPostHotResDto.of(hotPosts, size);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -256,7 +256,7 @@ public class PostService {
 
 
     @Transactional(readOnly = true)
-    public GetPostHotResDto findHotPosts(int cursor, int size) {
+    public GetPostHotResDto findHotPosts(Long cursor, int size) {
         List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetch(cursor, size);
         return GetPostHotResDto.from(hotPosts, size);
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -286,9 +286,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public GetPostHotResDto searchHotPosts(String keyword, Pageable pageable) {
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetchByKeyword(keyword.replaceAll(" ", ""), pageRequest);
-        return GetPostHotResDto.from(hotPosts, 10);
+    public GetPostHotResDto searchHotPosts(String keyword, Long cursor, int size) {
+        List<HotPost> hotPosts = hotPostRepository.findWithDetailsFetchByKeyword(keyword.replaceAll(" ", ""), cursor, size);
+        return GetPostHotResDto.from(hotPosts, size);
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/post/service/PostService.java
@@ -271,15 +271,13 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public GetPostResDto searchPosts(Long boardId, String keyword, Pageable pageable) {
+    public GetPostResDto searchPosts(Long boardId, String keyword, Long cursor, int size) {
         if (!boardRepository.existsById(boardId)) {
             throw new BoardException(BoardErrorInfo.NO_BOARD);
         }
 
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<Post> posts = postRepository.findWithDetailsFetchByBoardIdAndKeyword(boardId, keyword.replaceAll(" ", ""), pageRequest);
-
-        return GetPostResDto.of(posts, 10);
+        List<Post> posts = postRepository.findWithDetailsFetchByBoardIdAndKeyword(boardId, keyword.replaceAll(" ", ""), cursor, size);
+        return GetPostResDto.of(posts, size);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/global/config/QueryDslConfig.java
+++ b/src/main/java/com/ssafy/ssafsound/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.ssafy.ssafsound.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## Issues

- #149 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 커서 기반의 페이지 네이션 방식으로 수정
  - Hot 게시글 목록 조회
  - Hot 게시글 검색
  - 게시글 목록 조회
  - 게시글 검색
  - 나의 게시글 목록 조회
- QueryDsl 설정 추가

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->
목록 조회 관련 모든 기능을 커서 기반의 페이지네이션으로 수정했습니다. 이를 위해서는 QueryDsl로 쿼리문을 작성할 필요성이 있었습니다. 

요청데이터에 쿼리스트링의 page -> cursor필드로 수정하였습니다. 단, cursor 필드는 -1이 처음 페이지를 의미합니다.

- 요청 데이터의 cursor
  @khs960616 한성님은 null을 처음 페이지를 의미하도록 하였지만, 저는 -1로 두었는데 그 이유는 null값을 쿼리스트링으로 넣기 위해서는 null임을 체크한 후 Long타입의 cursor에 null을 할당하는 분기문 처리를 수행해야 하기 때문입니다.
  이 부분은 통일하면 좋을거 같습니다.
  

- 응답 데이터의 cursor
  현재 size만큼의 목록이 조회되고, 다음 페이지에 해당하는 데이터가 존재하면 마지막의 cursor 값이 응답으로 전달됩니다.
  예를들어 cursor=-1 size=3 을 두었을때 id가 9, 8, 7로 데이터가 출력된다면 응답 데이터의 cursor값은 7이 됩니다.
  만약 다음 페이지에 해당하는 데이터가 없다면 null이 응답됩니다.


## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
- build.gradle에 Querydsl 설정 추가

```
plugins {
	// querydsl 플러그인 추가
	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
}
```
플러그인에 querydsl을 추가했습니다.

```
ext {
	set('snippetsDir', file("build/generated-snippets"))

	// QueryDsl Version
	queryDslVersion = "5.0.0"
}
```
queryDslVersion을 사용하기 위해 버전을 명시해주었습니다.


```
dependencies {
	// querydsl 의존성 추가
	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
}
```
dependencies에 querydsl의 의존성을 추가해주었습니다.

```
// querydsl 사용할 경로 지정
def querydslDir = "build/generated"

// JPA 사용여부 및 사용 경로 설정
querydsl {
	jpa = true
	querydslSourcesDir = querydslDir
}

// build시 사용할 sourceSet 추가 설정
sourceSets {
	main.java.srcDir querydslDir
}


// querydsl 컴파일 시 사용할 옵션 설정
compileQuerydsl {
	options.annotationProcessorPath = configurations.querydsl
}

// querydsl이 compileClassPath를 상속하도록 설정
configurations {
	compileOnly {
		extendsFrom annotationProcessor
	}
	querydsl.extendsFrom compileClasspath
}
```
다음은 build.gradle 맨 아래부분에 추가한 설정입니다.

- 프로젝트 설정(gradle)
![image](https://github.com/SSAF-SOUND/ssaf-sound-be/assets/59381113/b39bad0c-f012-47e0-89ff-51f84e19b2b2)

Build And Run Using과 Run tests Using에서
Intellij IDEA로 설정되어 있다면, Gradle로 변경해주어야 합니다.

Gradle로 변경하지 않는다면 Q클래스가 자동적으로 import되지 않습니다.

- Q클래스
해당 설정을 추가한 후 build를 수행하면 자동으로 build 폴더안에 다음과 같은 도메인에 해당하는 Q클래스가 생성됩니다.
![image](https://github.com/SSAF-SOUND/ssaf-sound-be/assets/59381113/7da80e13-24b3-43f1-8e74-dc9a22b5a31b)


Querydsl 쿼리문을 작성할 때 Q클래스를 사용하면 됩니다.