### PR TITLE
refactor: member의 프로필 공개 여부에 따른 로직 리팩토링

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -38,6 +38,14 @@ public class MemberController {
                 .build();
     }
 
+    @GetMapping("/public-profile")
+    public EnvelopeResponse<GetMemberPublicProfileResDto> getMemberProfilePublic(
+            @Authentication AuthenticatedMember authenticatedMember) {
+        return EnvelopeResponse.<GetMemberPublicProfileResDto>builder()
+                .data(memberService.getMemberPublicProfileByMemberId(authenticatedMember.getMemberId()))
+                .build();
+    }
+
     @PutMapping
     public EnvelopeResponse<GetMemberResDto> registerMemberInformation(
             @Authentication AuthenticatedMember authenticatedMember,
@@ -82,12 +90,12 @@ public class MemberController {
                 .build();
     }
 
-    @PatchMapping("/profile-public")
-    public EnvelopeResponse patchMemberProfilePublic(
+    @PatchMapping("/public-profile")
+    public EnvelopeResponse patchMemberPublicProfile(
             @Authentication AuthenticatedMember authenticatedMember,
-            @Valid @RequestBody PatchMemberProfilePublicReqDto patchMemberProfilePublicReqDto) {
+            @Valid @RequestBody PatchMemberPublicProfileReqDto patchMemberPublicProfileReqDto) {
 
-        memberService.patchMemberProfilePublic(authenticatedMember.getMemberId(), patchMemberProfilePublicReqDto);
+        memberService.patchMemberPublicProfile(authenticatedMember.getMemberId(), patchMemberPublicProfileReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -32,9 +32,9 @@ public class MemberController {
     }
 
     @GetMapping("/{memberId}/default-information")
-    public EnvelopeResponse<GetMemberProfileResDto> getMemberProfileById(@PathVariable Long memberId) {
-        return EnvelopeResponse.<GetMemberProfileResDto>builder()
-                .data(memberService.getMemberProfileById(memberId))
+    public EnvelopeResponse<GetMemberDefaultInfoResDto> getMemberDefaultInfoByMemberId(@PathVariable Long memberId) {
+        return EnvelopeResponse.<GetMemberDefaultInfoResDto>builder()
+                .data(memberService.getMemberDefaultInfoByMemberId(memberId))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -99,4 +99,14 @@ public class MemberController {
         return EnvelopeResponse.builder()
                 .build();
     }
+
+    @PatchMapping("/nickname")
+    public EnvelopeResponse changeMemberNickname(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PatchMemberNicknameReqDto patchMemberNicknameReqDto) {
+
+        memberService.changeMemberNickname(authenticatedMember.getMemberId(), patchMemberNicknameReqDto);
+        return EnvelopeResponse.builder()
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -17,7 +17,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public EnvelopeResponse<GetMemberResDto> getMemberInformation(@Authentication AuthenticatedMember authenticatedMember) {
+    public EnvelopeResponse<GetMemberResDto> getMemberInformation(
+            @Authentication AuthenticatedMember authenticatedMember) {
         return EnvelopeResponse.<GetMemberResDto>builder()
                 .data(memberService.getMemberInformation(authenticatedMember))
                 .build();
@@ -38,31 +39,35 @@ public class MemberController {
     }
 
     @PutMapping
-    public EnvelopeResponse<GetMemberResDto> registerMemberInformation(@Authentication AuthenticatedMember authenticatedMember,
-                                                                       @Valid @RequestBody PostMemberInfoReqDto postMemberInfoReqDto) {
+    public EnvelopeResponse<GetMemberResDto> registerMemberInformation(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PostMemberInfoReqDto postMemberInfoReqDto) {
         return EnvelopeResponse.<GetMemberResDto>builder()
                 .data(memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto))
                 .build();
     }
 
     @PostMapping("/nickname")
-    public EnvelopeResponse<PostNicknameResDto> checkNicknamePossible(@Valid @RequestBody PostNicknameReqDto postNicknameReqDto) {
+    public EnvelopeResponse<PostNicknameResDto> checkNicknamePossible(
+            @Valid @RequestBody PostNicknameReqDto postNicknameReqDto) {
         return EnvelopeResponse.<PostNicknameResDto>builder()
                 .data(memberService.checkNicknamePossible(postNicknameReqDto))
                 .build();
     }
 
     @PostMapping("/ssafy-certification")
-    public EnvelopeResponse<PostCertificationInfoResDto> certifySSAFYInformation(@Authentication AuthenticatedMember authenticatedMember,
-                                                                                @Valid @RequestBody PostCertificationInfoReqDto postCertificationInfoReqDto) {
+    public EnvelopeResponse<PostCertificationInfoResDto> certifySSAFYInformation(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PostCertificationInfoReqDto postCertificationInfoReqDto) {
         return EnvelopeResponse.<PostCertificationInfoResDto>builder()
                 .data(memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto))
                 .build();
     }
 
     @PutMapping("/portfolio")
-    public EnvelopeResponse registerMemberPortfolio(@Authentication AuthenticatedMember authenticatedMember,
-                                                 @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
+    public EnvelopeResponse registerMemberPortfolio(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
         memberService.registerMemberPortfolio(authenticatedMember, putMemberProfileReqDto);
         return EnvelopeResponse.builder()
                 .build();
@@ -73,6 +78,16 @@ public class MemberController {
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
         memberService.patchMemberDefaultInfo(authenticatedMember.getMemberId(), patchMemberDefaultInfoReqDto);
+        return EnvelopeResponse.builder()
+                .build();
+    }
+
+    @PatchMapping("/profile-public")
+    public EnvelopeResponse patchMemberProfilePublic(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PatchMemberProfilePublicReqDto patchMemberProfilePublicReqDto) {
+
+        memberService.patchMemberProfilePublic(authenticatedMember.getMemberId(), patchMemberProfilePublicReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -31,7 +31,7 @@ public class MemberController {
                 .build();
     }
 
-    @GetMapping("/{memberId}/profile")
+    @GetMapping("/{memberId}/default-information")
     public EnvelopeResponse<GetMemberProfileResDto> getMemberProfileById(@PathVariable Long memberId) {
         return EnvelopeResponse.<GetMemberProfileResDto>builder()
                 .data(memberService.getMemberProfileById(memberId))

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -24,6 +24,26 @@ public class MemberController {
                 .build();
     }
 
+    /**
+     *  나의 포트폴리오 가져오기
+     * @author : YongsHub
+     * @param : memberId
+     * 나의 포트폴리오 조회는 공개 여부와 상관 없이 가져올 수 있어야 합니다.
+     */
+    @GetMapping("/portfolio")
+    public EnvelopeResponse<GetMemberPortfolioResDto> getMyPortfolio(
+            @Authentication AuthenticatedMember authenticatedMember) {
+        return EnvelopeResponse.<GetMemberPortfolioResDto>builder()
+                .data(memberService.getMyPortfolio(authenticatedMember.getMemberId()))
+                .build();
+    }
+
+    /**
+     *  멤버 포트폴리오 가져오기
+     * @author : YongsHub
+     * @param : memberId
+     * 멤버 포트폴리오 조회는 공개 여부에 따라 조회가 될 수도 있고 조회가 안될수 있습니다.
+     */
     @GetMapping("/{memberId}/portfolio")
     public EnvelopeResponse<GetMemberPortfolioResDto> getMemberPortfolioById(@PathVariable Long memberId) {
         return EnvelopeResponse.<GetMemberPortfolioResDto>builder()

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -77,10 +77,10 @@ public class MemberController {
     @PutMapping("/portfolio")
     public EnvelopeResponse registerMemberPortfolio(
             @Authentication AuthenticatedMember authenticatedMember,
-            @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
+            @Valid @RequestBody PutMemberPortfolioReqDto putMemberPortfolioReqDto) {
         memberService.registerMemberPortfolio(
                 authenticatedMember.getMemberId(),
-                putMemberProfileReqDto);
+                putMemberPortfolioReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -20,7 +20,7 @@ public class MemberController {
     public EnvelopeResponse<GetMemberResDto> getMemberInformation(
             @Authentication AuthenticatedMember authenticatedMember) {
         return EnvelopeResponse.<GetMemberResDto>builder()
-                .data(memberService.getMemberInformation(authenticatedMember))
+                .data(memberService.getMemberInformation(authenticatedMember.getMemberId()))
                 .build();
     }
 
@@ -68,7 +68,9 @@ public class MemberController {
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PostCertificationInfoReqDto postCertificationInfoReqDto) {
         return EnvelopeResponse.<PostCertificationInfoResDto>builder()
-                .data(memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto))
+                .data(memberService.certifySSAFYInformation(
+                        authenticatedMember.getMemberId(),
+                        postCertificationInfoReqDto))
                 .build();
     }
 
@@ -76,7 +78,9 @@ public class MemberController {
     public EnvelopeResponse registerMemberPortfolio(
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PutMemberProfileReqDto putMemberProfileReqDto) {
-        memberService.registerMemberPortfolio(authenticatedMember, putMemberProfileReqDto);
+        memberService.registerMemberPortfolio(
+                authenticatedMember.getMemberId(),
+                putMemberProfileReqDto);
         return EnvelopeResponse.builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -179,4 +179,8 @@ public class Member extends BaseTimeEntity {
     public void exchangeProfilePublic(Boolean isPublic) {
         this.publicProfile = isPublic;
     }
+
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -80,7 +80,7 @@ public class Member extends BaseTimeEntity {
 
     @Column
     @Builder.Default
-    private Boolean publicPortfolio = true;
+    private Boolean publicProfile = true;
 
     @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     @Builder.Default
@@ -174,5 +174,9 @@ public class Member extends BaseTimeEntity {
             this.setGeneralMemberInformation(postMemberInfoReqDto);
             return GetMemberResDto.fromGeneralUser(this);
         }
+    }
+
+    public void exchangeProfilePublic(Boolean isPublic) {
+        this.publicProfile = isPublic;
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberDefaultInfoResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberDefaultInfoResDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class GetMemberProfileResDto {
+public class GetMemberDefaultInfoResDto {
 
     private String nickname;
 
@@ -20,21 +20,21 @@ public class GetMemberProfileResDto {
 
     private SSAFYInfo ssafyInfo;
 
-    private GetMemberProfileResDto(String nickname, Boolean isMajor, Member member) {
+    private GetMemberDefaultInfoResDto(String nickname, Boolean isMajor, Member member) {
         this(nickname, isMajor);
         this.ssafyMember = true;
         this.ssafyInfo = SSAFYInfo.from(member);
     }
 
-    private GetMemberProfileResDto(String nickname,  Boolean isMajor) {
+    private GetMemberDefaultInfoResDto(String nickname, Boolean isMajor) {
         this.nickname = nickname;
         this.isMajor = isMajor;
     }
 
-    public static GetMemberProfileResDto from(Member member) {
+    public static GetMemberDefaultInfoResDto from(Member member) {
         if (member.getSsafyMember()) {
-            return new GetMemberProfileResDto(member.getNickname(), member.getMajor(), member);
+            return new GetMemberDefaultInfoResDto(member.getNickname(), member.getMajor(), member);
         }
-        return new GetMemberProfileResDto(member.getNickname(), member.getMajor());
+        return new GetMemberDefaultInfoResDto(member.getNickname(), member.getMajor());
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
@@ -28,4 +28,11 @@ public class GetMemberPortfolioResDto {
                 .isPublic(false)
                 .build();
     }
+
+    public static GetMemberPortfolioResDto ofMyPortfolio(Member member, MemberProfile memberProfile) {
+        return GetMemberPortfolioResDto.builder()
+                .isPublic(member.getPublicProfile())
+                .portfolioElement(PortfolioElement.of(member, memberProfile))
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
@@ -18,7 +18,7 @@ public class GetMemberPortfolioResDto {
     private PortfolioElement portfolioElement;
 
     public static GetMemberPortfolioResDto of(Member member, MemberProfile memberProfile) {
-        if(member.getPublicPortfolio()) {
+        if(member.getPublicProfile()) {
             return GetMemberPortfolioResDto.builder()
                     .isPublic(true)
                     .portfolioElement(PortfolioElement.of(member, memberProfile))

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPublicProfileResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPublicProfileResDto.java
@@ -1,0 +1,11 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetMemberPublicProfileResDto {
+
+    private Boolean isPublic;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberNicknameReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberNicknameReqDto.java
@@ -1,0 +1,18 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PatchMemberNicknameReqDto {
+
+    @NotNull
+    @Size(min = 1, max = 11)
+    private String nickname;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberProfilePublicReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberProfilePublicReqDto.java
@@ -1,0 +1,13 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PatchMemberProfilePublicReqDto {
+
+    private Boolean isPublic;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberPublicProfileReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberPublicProfileReqDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class PatchMemberProfilePublicReqDto {
+public class PatchMemberPublicProfileReqDto {
 
     private Boolean isPublic;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberPortfolioReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PutMemberPortfolioReqDto.java
@@ -13,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class PutMemberProfileReqDto {
+public class PutMemberPortfolioReqDto {
     private String selfIntroduction;
 
     @CheckSkills

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -155,6 +155,15 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public GetMemberPortfolioResDto getMyPortfolio(Long memberId) {
+        Member member = memberRepository.findWithMemberLinksAndMemberSkills(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+        MemberProfile memberProfile = memberProfileRepository.findMemberProfileByMember(member).orElseGet(MemberProfile::new);
+
+        return GetMemberPortfolioResDto.ofMyPortfolio(member, memberProfile);
+    }
+
+    @Transactional(readOnly = true)
     public GetMemberPublicProfileResDto getMemberPublicProfileByMemberId(Long memberId) {
         Member member = getMemberByMemberIdOrThrowException(memberId);
 
@@ -194,7 +203,8 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public GetMemberPortfolioResDto getMemberPortfolioById(Long memberId) {
-        Member member = getMemberByMemberIdOrThrowException(memberId);
+        Member member = memberRepository.findWithMemberLinksAndMemberSkills(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
         MemberProfile memberProfile = memberProfileRepository.findMemberProfileByMember(member).orElseGet(MemberProfile::new);
 
         return GetMemberPortfolioResDto.of(member, memberProfile);

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -201,9 +201,9 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public GetMemberProfileResDto getMemberProfileById(Long memberId) {
+    public GetMemberDefaultInfoResDto getMemberDefaultInfoByMemberId(Long memberId) {
         Member member = getMemberByMemberIdOrThrowException(memberId);
-        return GetMemberProfileResDto.from(member);
+        return GetMemberDefaultInfoResDto.from(member);
     }
 
     public void deleteExistMemberLinksAllByMemberAndSaveNewRequest(Member member, List<PutMemberLink> memberLinks) {

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -107,11 +107,11 @@ public class MemberService {
     @Transactional
     public void registerMemberPortfolio(
             Long memberId,
-            PutMemberProfileReqDto putMemberProfileReqDto) {
+            PutMemberPortfolioReqDto putMemberPortfolioReqDto) {
         Member member = getMemberByMemberIdOrThrowException(memberId);
-        setMemberPortfolioIntroduceByMember(member, putMemberProfileReqDto);
-        deleteExistMemberLinksAllByMemberAndSaveNewRequest(member, putMemberProfileReqDto.getMemberLinks());
-        deleteExistMemberSkillsAllByMemberAndSaveNewRequest(member, putMemberProfileReqDto.getSkills());
+        setMemberPortfolioIntroduceByMember(member, putMemberPortfolioReqDto);
+        deleteExistMemberLinksAllByMemberAndSaveNewRequest(member, putMemberPortfolioReqDto.getMemberLinks());
+        deleteExistMemberSkillsAllByMemberAndSaveNewRequest(member, putMemberPortfolioReqDto.getSkills());
     }
 
     /**
@@ -216,11 +216,11 @@ public class MemberService {
         member.setMemberSkills(memberSkills, metaDataConsumer);
     }
 
-    public void setMemberPortfolioIntroduceByMember(Member member, PutMemberProfileReqDto putMemberProfileReqDto) {
-        if (putMemberProfileReqDto.getSelfIntroduction() != null) {
+    public void setMemberPortfolioIntroduceByMember(Member member, PutMemberPortfolioReqDto putMemberPortfolioReqDto) {
+        if (putMemberPortfolioReqDto.getSelfIntroduction() != null) {
             memberProfileRepository.findMemberProfileByMember(member).ifPresentOrElse(
-                    memberProfile -> memberProfile.changeSelfIntroduction(putMemberProfileReqDto.getSelfIntroduction()),
-                    () -> memberProfileRepository.save(putMemberProfileReqDto.toMemberProfile(member))
+                    memberProfile -> memberProfile.changeSelfIntroduction(putMemberPortfolioReqDto.getSelfIntroduction()),
+                    () -> memberProfileRepository.save(putMemberPortfolioReqDto.toMemberProfile(member))
             );
         }
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -149,9 +149,8 @@ public class MemberService {
 
         if (isExistNickname) {
             throw new MemberException(MemberErrorInfo.MEMBER_NICKNAME_DUPLICATION);
-        } else {
-            member.changeNickname(patchMemberNicknameReqDto.getNickname());
         }
+        member.changeNickname(patchMemberNicknameReqDto.getNickname());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -131,6 +131,16 @@ public class MemberService {
         member.exchangeDefaultInformation(patchMemberDefaultInfoReqDto, metaDataConsumer);
     }
 
+    @Transactional
+    public void patchMemberProfilePublic(
+            Long memberId,
+            PatchMemberProfilePublicReqDto patchMemberProfilePublicReqDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        member.exchangeProfilePublic(patchMemberProfilePublicReqDto.getIsPublic());
+    }
+
     @Transactional(readOnly = true)
     public MemberRole findMemberRoleByRoleName(String roleType) {
         return memberRoleRepository.findByRoleType(roleType).orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_ROLE_TYPE_NOT_FOUND));

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -141,6 +141,21 @@ public class MemberService {
         member.exchangeProfilePublic(patchMemberPublicProfileReqDto.getIsPublic());
     }
 
+    @Transactional
+    public void changeMemberNickname(
+            Long memberId,
+            PatchMemberNicknameReqDto patchMemberNicknameReqDto) {
+        boolean isExistNickname = memberRepository.existsByNickname(patchMemberNicknameReqDto.getNickname());
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        if (isExistNickname) {
+            throw new MemberException(MemberErrorInfo.MEMBER_NICKNAME_DUPLICATION);
+        } else {
+            member.changeNickname(patchMemberNicknameReqDto.getNickname());
+        }
+    }
+
     @Transactional(readOnly = true)
     public GetMemberPublicProfileResDto getMemberPublicProfileByMemberId(Long memberId) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -132,13 +132,23 @@ public class MemberService {
     }
 
     @Transactional
-    public void patchMemberProfilePublic(
+    public void patchMemberPublicProfile(
             Long memberId,
-            PatchMemberProfilePublicReqDto patchMemberProfilePublicReqDto) {
+            PatchMemberPublicProfileReqDto patchMemberPublicProfileReqDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
-        member.exchangeProfilePublic(patchMemberProfilePublicReqDto.getIsPublic());
+        member.exchangeProfilePublic(patchMemberPublicProfileReqDto.getIsPublic());
+    }
+
+    @Transactional(readOnly = true)
+    public GetMemberPublicProfileResDto getMemberPublicProfileByMemberId(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        return GetMemberPublicProfileResDto.builder()
+                .isPublic(member.getPublicProfile())
+                .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -457,4 +457,31 @@ class MemberServiceTest {
         //verify
         verify(memberRepository, times(1)).findById(member.getId());
     }
+
+    @Test
+    @DisplayName("마이 프로필 공개 여부 조회 시도 시, 회원 정보를 찾을 수 없다면 예외가 발생한다")
+    void Given_IsNotExistMember_When_Get_Public_Profile_Then_ThrowMemberException() {
+        //given
+        given(memberRepository.findById(member.getId())).willReturn(Optional.empty());
+
+        //then
+        assertThrows(MemberException.class,
+                () -> memberService.getMemberPublicProfileByMemberId(member.getId()));
+
+        //verify
+        verify(memberRepository, times(1)).findById(member.getId());
+    }
+
+    @Test
+    @DisplayName("마이 프로필 공개 여부 조회에 성공한다.")
+    void Given_Valid_Member_When_Get_Public_Profile_Then_Success() {
+        //given
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+
+        //then
+        memberService.getMemberPublicProfileByMemberId(member.getId());
+
+        //verify
+        verify(memberRepository, times(1)).findById(member.getId());
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -416,7 +416,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("싸피생 인증 요청 시, 회원 정보를 찾을 수 없다면 예외가 발생한다.")
-    void Given_Given_PostCertificationInfo_When_Submit_SSAFY_Certification_Answer_Then_ThrowMemberException() {
+    void Given_PostCertificationInfo_When_Submit_SSAFY_Certification_Answer_Then_ThrowMemberException() {
         PostCertificationInfoReqDto postCertificationInfoReqDto = PostCertificationInfoReqDto.builder()
                 .semester(1)
                 .answer("선물")

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -5,9 +5,7 @@ import com.ssafy.ssafsound.domain.auth.service.token.JwtTokenProvider;
 import com.ssafy.ssafsound.domain.member.domain.*;
 import com.ssafy.ssafsound.domain.member.dto.*;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
-import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
-import com.ssafy.ssafsound.domain.member.repository.MemberRoleRepository;
-import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
+import com.ssafy.ssafsound.domain.member.repository.*;
 import com.ssafy.ssafsound.domain.meta.domain.*;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +35,12 @@ class MemberServiceTest {
     private MemberRoleRepository memberRoleRepository;
     @Mock
     private MemberTokenRepository memberTokenRepository;
+    @Mock
+    private MemberProfileRepository memberProfileRepository;
+    @Mock
+    private MemberLinkRepository memberLinkRepository;
+    @Mock
+    private MemberSkillRepository memberSkillRepository;
     @Mock
     private MetaDataConsumer metaDataConsumer;
     @Mock
@@ -485,5 +489,25 @@ class MemberServiceTest {
 
         //verify
         verify(memberRepository, times(1)).findById(member.getId());
+    }
+
+
+    @Test
+    @DisplayName("멤버의 포트폴리오 정보를 수정하는데 성공한다.")
+    void Given_Valid_Member_Portfolio_Information_When_Put_Portfolio_Then_Success() {
+        //given
+        Member mockMember = mock(Member.class);
+        MemberProfile mockMemberProfile = mock(MemberProfile.class);
+        PutMemberPortfolioReqDto putMemberPortfolioReqDto = mock(PutMemberPortfolioReqDto.class);
+        given(mockMember.getId()).willReturn(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(mockMember));
+        given(putMemberPortfolioReqDto.getSelfIntroduction()).willReturn("자기소개 합니다.");
+        given(memberProfileRepository.findMemberProfileByMember(mockMember)).willReturn(Optional.of(mockMemberProfile));
+
+        //then
+        memberService.registerMemberPortfolio(mockMember.getId(), putMemberPortfolioReqDto);
+
+        //verify
+        verify(memberRepository, times(1)).findById(mockMember.getId());
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -239,7 +239,7 @@ class MemberServiceTest {
         GetMemberResDto getMemberResDto = GetMemberResDto.fromGeneralUser(member);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
 
-        GetMemberResDto result = memberService.getMemberInformation(authenticatedMember);
+        GetMemberResDto result = memberService.getMemberInformation(authenticatedMember.getMemberId());
 
         assertAll(
                 () -> assertThat(result.getMemberId()).isEqualTo(getMemberResDto.getMemberId()),
@@ -258,7 +258,7 @@ class MemberServiceTest {
         GetMemberResDto getMemberResDto = GetMemberResDto.fromGeneralUser(member);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
 
-        GetMemberResDto result = memberService.getMemberInformation(authenticatedMember);
+        GetMemberResDto result = memberService.getMemberInformation(authenticatedMember.getMemberId());
 
         assertAll(
                 () -> assertThat(result.getMemberId()).isEqualTo(getMemberResDto.getMemberId()),
@@ -278,7 +278,7 @@ class MemberServiceTest {
         GetMemberResDto getMemberResDto = GetMemberResDto.fromSSAFYUser(member);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
 
-        GetMemberResDto result = memberService.getMemberInformation(authenticatedMember);
+        GetMemberResDto result = memberService.getMemberInformation(authenticatedMember.getMemberId());
 
         assertAll(
                 () -> assertThat(result.getMemberId()).isEqualTo(getMemberResDto.getMemberId()),
@@ -379,7 +379,7 @@ class MemberServiceTest {
         given(memberConstantProvider.getMAX_MINUTES()).willReturn(5);
 
         PostCertificationInfoResDto postCertificationInfoResDto = memberService
-                .certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto);
+                .certifySSAFYInformation(authenticatedMember.getMemberId(), postCertificationInfoReqDto);
 
         assertThat(member.getCertificationState()).isEqualTo(AuthenticationStatus.CERTIFIED);
         assertThat(member.getMajorTrack().getName()).isEqualTo(majorTrack);
@@ -406,7 +406,8 @@ class MemberServiceTest {
         given(memberConstantProvider.getMAX_MINUTES()).willReturn(5);
         given(memberConstantProvider.getCERTIFICATION_INQUIRY_TIME()).willReturn(5);
 
-        PostCertificationInfoResDto postCertificationInfoResDto = memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto);
+        PostCertificationInfoResDto postCertificationInfoResDto = memberService.certifySSAFYInformation(
+                authenticatedMember.getMemberId(), postCertificationInfoReqDto);
 
         assertThat(postCertificationInfoResDto.isPossible()).isFalse();
 
@@ -424,7 +425,8 @@ class MemberServiceTest {
 
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.empty());
 
-        assertThrows(MemberException.class, () -> memberService.certifySSAFYInformation(authenticatedMember, postCertificationInfoReqDto));
+        assertThrows(MemberException.class, () -> memberService.certifySSAFYInformation(
+                authenticatedMember.getMemberId(), postCertificationInfoReqDto));
 
         verify(memberRepository).findById(authenticatedMember.getMemberId());
     }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -496,18 +496,30 @@ class MemberServiceTest {
     @DisplayName("멤버의 포트폴리오 정보를 수정하는데 성공한다.")
     void Given_Valid_Member_Portfolio_Information_When_Put_Portfolio_Then_Success() {
         //given
-        Member mockMember = mock(Member.class);
-        MemberProfile mockMemberProfile = mock(MemberProfile.class);
         PutMemberPortfolioReqDto putMemberPortfolioReqDto = mock(PutMemberPortfolioReqDto.class);
-        given(mockMember.getId()).willReturn(1L);
-        given(memberRepository.findById(1L)).willReturn(Optional.of(mockMember));
+        MemberProfile memberProfile = mock(MemberProfile.class);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
         given(putMemberPortfolioReqDto.getSelfIntroduction()).willReturn("자기소개 합니다.");
-        given(memberProfileRepository.findMemberProfileByMember(mockMember)).willReturn(Optional.of(mockMemberProfile));
+        given(memberProfileRepository.findMemberProfileByMember(member)).willReturn(Optional.of(memberProfile));
 
         //then
-        memberService.registerMemberPortfolio(mockMember.getId(), putMemberPortfolioReqDto);
+        memberService.registerMemberPortfolio(member.getId(), putMemberPortfolioReqDto);
 
         //verify
-        verify(memberRepository, times(1)).findById(mockMember.getId());
+        verify(memberRepository, times(1)).findById(member.getId());
+    }
+
+    @Test
+    @DisplayName("멤버의 닉네임을 수정하는데 성공한다.")
+    void Given_Nickname_When_ChangeNickname_Then_Success() {
+        //given
+        PatchMemberNicknameReqDto patchMemberNicknameReqDto = mock(PatchMemberNicknameReqDto.class);
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+
+        //then
+        memberService.changeMemberNickname(member.getId(), patchMemberNicknameReqDto);
+
+        //verify
+        verify(memberRepository, times(1)).findById(member.getId());
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -428,4 +428,33 @@ class MemberServiceTest {
 
         verify(memberRepository).findById(authenticatedMember.getMemberId());
     }
+
+    @Test
+    @DisplayName("마이 프로필 공개 여부 수정 시도 시, 회원 정보를 찾을 수 없다면 예외가 발생한다")
+    void Given_IsNotExistMember_When_Try_Change_Public_Profile_Then_ThrowMemberException() {
+        //given
+        PatchMemberPublicProfileReqDto patchMemberPublicProfileReqDto = new PatchMemberPublicProfileReqDto();
+        given(memberRepository.findById(member.getId())).willReturn(Optional.empty());
+
+        //then
+        assertThrows(MemberException.class,
+                () -> memberService.patchMemberPublicProfile(member.getId(), patchMemberPublicProfileReqDto));
+
+        //verify
+        verify(memberRepository, times(1)).findById(member.getId());
+    }
+
+    @Test
+    @DisplayName("마이 프로필 공개 여부 수정에 성공한다.")
+    void Given_Valid_PatchMemberPublicProfileReqDto_When_Try_Change_Public_Profile_Then_Success() {
+        //given
+        PatchMemberPublicProfileReqDto patchMemberPublicProfileReqDto = new PatchMemberPublicProfileReqDto(false);
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+
+        //then
+        memberService.patchMemberPublicProfile(member.getId(), patchMemberPublicProfileReqDto);
+
+        //verify
+        verify(memberRepository, times(1)).findById(member.getId());
+    }
 }


### PR DESCRIPTION
## Issues

- #166 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

-  멤버의 공개 여부를 따로 조회할 수 있는 api GET /members/public-profile 로 추가했습니다.
마이페이지에서 조회할 수 있는 데이터는
사용자의 기본 정보, 사용자 포트폴리오, 나의 프로젝트/스터디 이기 때문에
Front입장에서는 먼저 공개 여부를 조회하고 데이터를 가져올 수 있도록 합의했습니다.
- 공개여부 필드에 대해 publicPortfolio -> publicProfile로 변경했습니다.
- PutMemberProfileDto라는 네이밍에서 -> 포트폴리오 입력이기 때문에 PutMemberPortfolioDto 로 변경했습니다.
- memberId에 대해 조회하는 로직이 공통적이라 생각해서 따로 메서드로 분리했습니다.
- 메서드 줄바꿈에 대해 수정된 부분이 몇몇 존재합니다. -> 따로 작업했어야 했는데 작업하면서 너무 보기 불편해서 같이 했네요 주의하겠습니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
