### PR TITLE
[TEST] MetaDataController Rest Docs With Rest Assured 

### DIFF
--- a/src/docs/asciidoc/metadata.adoc
+++ b/src/docs/asciidoc/metadata.adoc
@@ -1,9 +1,9 @@
 == 메타데이터
 === 캠퍼스 목록 조회
-operation::meta-data-controller-test/find-campuses[snippets='http-request,http-response,response-fields']
+operation::meta/campuses[snippets='http-request,http-response,response-fields']
 
 === 스킬 목록 조회
-operation::meta-data-controller-test/find-skills[snippets='http-request,http-response,response-fields']
+operation::meta/skills[snippets='http-request,http-response,response-fields']
 
 === 리크루트 목록 조회
-operation::meta-data-controller-test/find-recruit-types[snippets='http-request,http-response,response-fields']
+operation::meta/recruit-types[snippets='http-request,http-response,response-fields']

--- a/src/test/java/com/ssafy/ssafsound/domain/meta/controller/MetaControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/meta/controller/MetaControllerTest.java
@@ -1,0 +1,79 @@
+package com.ssafy.ssafsound.domain.meta.controller;
+
+import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
+import com.ssafy.ssafsound.domain.meta.fixture.ProductionMetaDataFixture;
+import com.ssafy.ssafsound.global.docs.ControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MetaControllerTest extends ControllerTest {
+
+    @DisplayName("캠퍼스 목록 조회에 성공합니다.")
+    @Test
+    void getCampuses() {
+
+        given(enumMetaDataConsumer.getMetaDataList(MetaDataType.CAMPUS.name()))
+                .willReturn(ProductionMetaDataFixture.CAMPUSES);
+
+        restDocs
+                .when().get("/meta/campuses")
+                .then().log().all()
+                .assertThat()
+                .apply(document("meta/campuses",
+                    getEnvelopPatternWithData()
+                        .andWithPrefix("data.campuses[].",
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("캠퍼스 id (미사용)"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("캠퍼스 이름")
+                        )
+                    )
+                ).expect(status().isOk());
+    }
+
+    @DisplayName("스킬 목록 조회에 성공합니다.")
+    @Test
+    void getSkills() {
+
+        given(enumMetaDataConsumer.getMetaDataList(MetaDataType.SKILL.name()))
+                .willReturn(ProductionMetaDataFixture.SKILLS);
+
+        restDocs
+                .when().get("/meta/skills")
+                .then().log().all()
+                .assertThat()
+                .apply(document("meta/skills",
+                        getEnvelopPatternWithData()
+                                .andWithPrefix("data.skills[].",
+                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("스킬 id (미사용)"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("스킬 이름")
+                                )
+                        )
+                ).expect(status().isOk());
+    }
+
+    @DisplayName("리크루트 모집타입 목록 조회에 성공합니다.")
+    @Test
+    void getRecruitTypes() {
+
+        given(enumMetaDataConsumer.getMetaDataList(MetaDataType.RECRUIT_TYPE.name()))
+                .willReturn(ProductionMetaDataFixture.RECRUIT_TYPES);
+
+        restDocs
+                .when().get("/meta/recruit-types")
+                .then().log().all()
+                .assertThat()
+                .apply(document("meta/recruit-types",
+                        getEnvelopPatternWithData()
+                                .andWithPrefix("data.recruitTypes[].",
+                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("리크루트 모집타입  id (미사용)"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("리크루트 모집타입 이름")
+                                )
+                        )
+                ).expect(status().isOk());
+    }
+}

--- a/src/test/java/com/ssafy/ssafsound/domain/meta/fixture/ProductionMetaDataFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/meta/fixture/ProductionMetaDataFixture.java
@@ -1,0 +1,17 @@
+package com.ssafy.ssafsound.domain.meta.fixture;
+
+import com.ssafy.ssafsound.domain.meta.domain.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ProductionMetaDataFixture {
+
+    public static final List<MetaData> CAMPUSES = convertEnumToMetaDataList(Campus.class);
+    public static final List<MetaData> SKILLS = convertEnumToMetaDataList(Skill.class);
+    public static final List<MetaData> RECRUIT_TYPES = convertEnumToMetaDataList(RecruitType.class);
+
+    private static List<MetaData> convertEnumToMetaDataList(Class<? extends MetaDataProvider> enumClass) {
+        return Arrays.stream(enumClass.getEnumConstants()).map(MetaData::new).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Issues

- #197 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [x] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- Rest Docs(문서화)을 위한 메타데이터 컨트롤러 테스트 추가
- 실제 운영 기반 데이터 반영을 위한 픽스쳐 추가

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

1. 해당 테스트의 경우 실제 운영 환경에서 활용되는 데이터가 명시적으로 제공되어야하므로, 임의의 MetaData 객체를 생성하기보다, 
기존 enum클래스를 기반으로 fixture을 만들도록 구성했습니다. 해당 부분에 문제가 없을지 같이 고민해주세요.

2. MetaControllerTest.java에서, enumMetaDataConsumer에 parameter로 any()를 넣은 경우, 문서화를 위한 코드이긴 하지만
메타데이터의 특성상 테스트코드의 의미가 이상하다고 느꼈습니다.  따라서 이 경우에는 실제로 들어가야될 parameter를 넣었습니다. (차후 Request Body, Query String으로 부터 받는 DTO를 넣는 경우에는 any로 mocking 해서 넣으려고 해요.)  이 부분 문제 없을지 확인 부탁드립니다. 

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
