### PR TITLE
[REFACTOR] 마이 프로필 조회 관련 기획 변경으로 인한 리팩토링

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -66,6 +66,13 @@ public class MemberController {
                 .build();
     }
 
+    @GetMapping("/{memberId}/public-profile")
+    public EnvelopeResponse<GetMemberPublicProfileResDto> getOtherMemberProfilePublic(@PathVariable Long memberId) {
+        return EnvelopeResponse.<GetMemberPublicProfileResDto>builder()
+                .data(memberService.getMemberPublicProfileByMemberId(memberId))
+                .build();
+    }
+
     @PutMapping
     public EnvelopeResponse<GetMemberResDto> registerMemberInformation(
             @Authentication AuthenticatedMember authenticatedMember,

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberProfile.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/MemberProfile.java
@@ -19,7 +19,8 @@ public class MemberProfile {
     private Long id;
 
     @Column
-    private String introduce;
+    @Builder.Default
+    private String introduce = "";
 
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
@@ -13,25 +13,20 @@ import lombok.NoArgsConstructor;
 @Getter
 public class GetMemberPortfolioResDto {
 
-    private Boolean isPublic;
-
     private PortfolioElement portfolioElement;
 
     public static GetMemberPortfolioResDto of(Member member, MemberProfile memberProfile) {
         if(member.getPublicProfile()) {
             return GetMemberPortfolioResDto.builder()
-                    .isPublic(true)
                     .portfolioElement(PortfolioElement.of(member, memberProfile))
                     .build();
         }
         return GetMemberPortfolioResDto.builder()
-                .isPublic(false)
                 .build();
     }
 
     public static GetMemberPortfolioResDto ofMyPortfolio(Member member, MemberProfile memberProfile) {
         return GetMemberPortfolioResDto.builder()
-                .isPublic(member.getPublicProfile())
                 .portfolioElement(PortfolioElement.of(member, memberProfile))
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/GetMemberPortfolioResDto.java
@@ -15,17 +15,7 @@ public class GetMemberPortfolioResDto {
 
     private PortfolioElement portfolioElement;
 
-    public static GetMemberPortfolioResDto of(Member member, MemberProfile memberProfile) {
-        if(member.getPublicProfile()) {
-            return GetMemberPortfolioResDto.builder()
-                    .portfolioElement(PortfolioElement.of(member, memberProfile))
-                    .build();
-        }
-        return GetMemberPortfolioResDto.builder()
-                .build();
-    }
-
-    public static GetMemberPortfolioResDto ofMyPortfolio(Member member, MemberProfile memberProfile) {
+    public static GetMemberPortfolioResDto ofMemberProfile(Member member, MemberProfile memberProfile) {
         return GetMemberPortfolioResDto.builder()
                 .portfolioElement(PortfolioElement.of(member, memberProfile))
                 .build();

--- a/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
@@ -12,7 +12,8 @@ public enum MemberErrorInfo {
     MEMBER_INFORMATION_ERROR("710", "멤버 정보 조회에서 문제가 발생했습니다."),
     MEMBER_NICKNAME_DUPLICATION("711", "중복되는 닉네임입니다."),
     MEMBER_CERTIFICATED_FAIL("712", "인증 시도 가능 횟수를 초과하여 일정 시간이 자나야 재시도 할 수 있습니다."),
-    SEMESTER_NOT_FOUND("713", "SSAFY Member 등록 또는 기수 수정 시, 기수 값은 필수입니다.");
+    SEMESTER_NOT_FOUND("713", "SSAFY Member 등록 또는 기수 수정 시, 기수 값은 필수입니다."),
+    MEMBER_PROFILE_SECRET("714", "멤버의 프로필 공개 여부를 확인하세요");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -159,7 +159,7 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
         MemberProfile memberProfile = memberProfileRepository.findMemberProfileByMember(member).orElseGet(MemberProfile::new);
 
-        return GetMemberPortfolioResDto.ofMyPortfolio(member, memberProfile);
+        return GetMemberPortfolioResDto.ofMemberProfile(member, memberProfile);
     }
 
     @Transactional(readOnly = true)
@@ -204,9 +204,13 @@ public class MemberService {
     public GetMemberPortfolioResDto getMemberPortfolioById(Long memberId) {
         Member member = memberRepository.findWithMemberLinksAndMemberSkills(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+
+        if (isPrivateOfMemberProfile(member)) {
+            throw new MemberException(MemberErrorInfo.MEMBER_PROFILE_SECRET);
+        }
         MemberProfile memberProfile = memberProfileRepository.findMemberProfileByMember(member).orElseGet(MemberProfile::new);
 
-        return GetMemberPortfolioResDto.of(member, memberProfile);
+        return GetMemberPortfolioResDto.ofMemberProfile(member, memberProfile);
     }
 
     @Transactional(readOnly = true)
@@ -232,6 +236,10 @@ public class MemberService {
                     () -> memberProfileRepository.save(putMemberPortfolioReqDto.toMemberProfile(member))
             );
         }
+    }
+
+    private boolean isPrivateOfMemberProfile(Member member) {
+        return !member.getPublicProfile();
     }
 
     private boolean isInvalidOauthLogin(Member member, PostMemberReqDto postMemberReqDto) {


### PR DESCRIPTION
## Issues

- #203 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

1) public 공개여부는 포트폴리오, 프로젝트, 리쿠르팅 각각에 대해서가 아닌, 프로필 공개여부 api에서 확인

2) 프로필 공개여부가 public이 아니라면, 포트폴리오, 프로젝트, 리쿠르팅을 선택할 수 있는 탭이 그려지지 않으므로, 요청도 가지 않음 (포트폴리오 탭을 선택하면 포트폴리오 요청이, 프로젝트 탭을 선택하면 프로젝트 요청이, 리쿠르팅 탭을 선택하면 리쿠르팅 요청이 갑니다.)
@khs960616 MemberProfile의 공개여부를 활용해서 리크루팅이나 프로젝트를 내려주면 될 것 같아요

3) 따라서 프로필 공개여부가 private인데 포트폴리오, 프로젝트, 리쿠르팅 요청을 시도하는것 자체가 논리적으로 오류 —> 따라서 private인데 요청할 경우, 성공응답으로 null을 주는게 아닌, 클라이언트 측 오류로 판단

4) 결론적으로 isPublic 필드가 필요하지 않고, 포트폴리오 데이터만 줍니다.


<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
