### PR TITLE
feat: 멤버의 전공자 유무 및 전공트랙 수정 API 추가

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -50,3 +50,6 @@ operation::members/change-nickname/[snippets='cookie,http-request,request-fields
 
 === 멤버의 전공자 여부 수정
 operation::members/change-isMajor/[snippets='cookie,http-request,request-fields,http-response,response-fields']
+
+=== 멤버의 전공트랙 수정
+operation::members/change-majorTrack/[snippets='cookie,http-request,request-fields,http-response,response-fields']

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -47,3 +47,6 @@ operation::members/check-nickname/[snippets='cookie,http-request,request-fields,
 
 === 닉네임 변경
 operation::members/change-nickname/[snippets='cookie,http-request,request-fields,http-response,response-fields']
+
+=== 멤버의 전공자 여부 수정
+operation::members/change-isMajor/[snippets='cookie,http-request,request-fields,http-response,response-fields']

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
     }
 
     @DeleteMapping("/logout")
-    public EnvelopeResponse logout(@CookieValue(value = "accessToken", defaultValue = "") String accessToken,
+    public EnvelopeResponse<Void> logout(@CookieValue(value = "accessToken", defaultValue = "") String accessToken,
                                    @CookieValue(value = "refreshToken", defaultValue = "") String refreshToken,
                                    HttpServletResponse response) {
 
@@ -44,7 +44,7 @@ public class AuthController {
             authService.deleteTokens(accessToken, refreshToken);
             cookieProvider.setResponseWithCookies(response, null, null);
         }
-        return EnvelopeResponse.builder().build();
+        return EnvelopeResponse.<Void>builder().build();
     }
 
     @GetMapping("/reissue")

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -102,42 +102,42 @@ public class MemberController {
     }
 
     @PutMapping("/portfolio")
-    public EnvelopeResponse registerMemberPortfolio(
+    public EnvelopeResponse<Void> registerMemberPortfolio(
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PutMemberPortfolioReqDto putMemberPortfolioReqDto) {
         memberService.registerMemberPortfolio(
                 authenticatedMember.getMemberId(),
                 putMemberPortfolioReqDto);
-        return EnvelopeResponse.builder()
+        return EnvelopeResponse.<Void>builder()
                 .build();
     }
 
     @PatchMapping("/default-information")
-    public EnvelopeResponse patchMemberDefaultInformation(
+    public EnvelopeResponse<Void> patchMemberDefaultInformation(
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PatchMemberDefaultInfoReqDto patchMemberDefaultInfoReqDto) {
         memberService.patchMemberDefaultInfo(authenticatedMember.getMemberId(), patchMemberDefaultInfoReqDto);
-        return EnvelopeResponse.builder()
+        return EnvelopeResponse.<Void>builder()
                 .build();
     }
 
     @PatchMapping("/public-profile")
-    public EnvelopeResponse patchMemberPublicProfile(
+    public EnvelopeResponse<Void> patchMemberPublicProfile(
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PatchMemberPublicProfileReqDto patchMemberPublicProfileReqDto) {
 
         memberService.patchMemberPublicProfile(authenticatedMember.getMemberId(), patchMemberPublicProfileReqDto);
-        return EnvelopeResponse.builder()
+        return EnvelopeResponse.<Void>builder()
                 .build();
     }
 
     @PatchMapping("/nickname")
-    public EnvelopeResponse changeMemberNickname(
+    public EnvelopeResponse<Void> changeMemberNickname(
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PatchMemberNicknameReqDto patchMemberNicknameReqDto) {
 
         memberService.changeMemberNickname(authenticatedMember.getMemberId(), patchMemberNicknameReqDto);
-        return EnvelopeResponse.builder()
+        return EnvelopeResponse.<Void>builder()
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.ssafy.ssafsound.domain.member.service.MemberService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
 import javax.validation.Valid;
 
 @RestController
@@ -127,6 +128,16 @@ public class MemberController {
             @Valid @RequestBody PatchMemberPublicProfileReqDto patchMemberPublicProfileReqDto) {
 
         memberService.patchMemberPublicProfile(authenticatedMember.getMemberId(), patchMemberPublicProfileReqDto);
+        return EnvelopeResponse.<Void>builder()
+                .build();
+    }
+
+    @PatchMapping("/major")
+    public EnvelopeResponse<Void> patchMemberIsMajor(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PatchMemberMajorReqDto patchMemberMajorReqDto) {
+
+        memberService.changeMemberMajor(authenticatedMember.getMemberId(), patchMemberMajorReqDto);
         return EnvelopeResponse.<Void>builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -142,6 +142,18 @@ public class MemberController {
                 .build();
     }
 
+    @PatchMapping("/major-track")
+    public EnvelopeResponse<Void> patchMemberMajorTrack(
+            @Authentication AuthenticatedMember authenticatedMember,
+            @Valid @RequestBody PatchMemberMajorTrackReqDto patchMemberMajorTrackReqDto) {
+
+        memberService.changeMemberMajorTrack(
+                authenticatedMember.getMemberId(),
+                patchMemberMajorTrackReqDto.getMajorTrack());
+        return EnvelopeResponse.<Void>builder()
+                .build();
+    }
+
     @PatchMapping("/nickname")
     public EnvelopeResponse<Void> changeMemberNickname(
             @Authentication AuthenticatedMember authenticatedMember,

--- a/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/domain/Member.java
@@ -183,4 +183,8 @@ public class Member extends BaseTimeEntity {
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void changeMajorStatus(Boolean isMajor) {
+        this.major = isMajor;
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberMajorReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberMajorReqDto.java
@@ -1,0 +1,18 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PatchMemberMajorReqDto {
+
+    @NotNull
+    private Boolean isMajor;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberMajorTrackReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PatchMemberMajorTrackReqDto.java
@@ -1,0 +1,18 @@
+package com.ssafy.ssafsound.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PatchMemberMajorTrackReqDto {
+
+    @NotNull
+    private String majorTrack;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
@@ -13,7 +13,9 @@ public enum MemberErrorInfo {
     MEMBER_NICKNAME_DUPLICATION("711", "중복되는 닉네임입니다."),
     MEMBER_CERTIFICATED_FAIL("712", "인증 시도 가능 횟수를 초과하여 일정 시간이 자나야 재시도 할 수 있습니다."),
     SEMESTER_NOT_FOUND("713", "SSAFY Member 등록 또는 기수 수정 시, 기수 값은 필수입니다."),
-    MEMBER_PROFILE_SECRET("714", "멤버의 프로필 공개 여부를 확인하세요");
+    MEMBER_PROFILE_SECRET("714", "멤버의 프로필 공개 여부를 확인하세요"),
+
+    MEMBER_NOT_SSAFY("715", "싸피생이 아닙니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafsound.domain.member.dto.*;
 import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.*;
+import com.ssafy.ssafsound.domain.meta.domain.MajorTrack;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
@@ -160,6 +161,13 @@ public class MemberService {
         Member member = getMemberByMemberIdOrThrowException(memberId);
 
         member.changeMajorStatus(patchMemberMajorReqDto.getIsMajor());
+    }
+
+    @Transactional
+    public void changeMemberMajorTrack(Long memberId, String majorTrack) {
+        Member member = getMemberByMemberIdOrThrowException(memberId);
+
+        member.setMajorTrack(metaDataConsumer.getMetaData(MetaDataType.MAJOR_TRACK.name(), majorTrack));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -167,6 +167,9 @@ public class MemberService {
     public void changeMemberMajorTrack(Long memberId, String majorTrack) {
         Member member = getMemberByMemberIdOrThrowException(memberId);
 
+        if(!member.getSsafyMember()) {
+            throw new MemberException(MemberErrorInfo.MEMBER_NOT_SSAFY);
+        }
         member.setMajorTrack(metaDataConsumer.getMetaData(MetaDataType.MAJOR_TRACK.name(), majorTrack));
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -153,6 +153,15 @@ public class MemberService {
         member.changeNickname(patchMemberNicknameReqDto.getNickname());
     }
 
+    @Transactional
+    public void changeMemberMajor(
+            Long memberId,
+            PatchMemberMajorReqDto patchMemberMajorReqDto) {
+        Member member = getMemberByMemberIdOrThrowException(memberId);
+
+        member.changeMajorStatus(patchMemberMajorReqDto.getIsMajor());
+    }
+
     @Transactional(readOnly = true)
     public GetMemberPortfolioResDto getMyPortfolio(Long memberId) {
         Member member = memberRepository.findWithMemberLinksAndMemberSkills(memberId)

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -471,17 +471,72 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_토큰_재발급">5.5. 토큰 재발급</a></li>
 </ul>
 </li>
-<li><a href="#_점심">6. 점심</a>
+<li><a href="#_멤버">6. 멤버</a>
 <ul class="sectlevel2">
-<li><a href="#_점심_목록_조회">6.1. 점심 목록 조회</a></li>
-<li><a href="#_점심_상세_조회">6.2. 점심 상세 조회</a></li>
-<li><a href="#_점심_투표하기">6.3. 점심 투표하기</a></li>
-<li><a href="#_점심_투표_취소하기">6.4. 점심 투표 취소하기</a></li>
+<li><a href="#_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다">6.1. 소셜 로그인 후 멤버를 조회 했을때, 나갈 수 있기 때문에 ssafyMember가 null 이라면 회원가입을 진행해야 합니다.</a></li>
+<li><a href="#_일반_멤버_정보_조회">6.2. 일반 멤버 정보 조회</a></li>
+<li><a href="#_싸피생_멤버_정보_조회">6.3. 싸피생 멤버 정보 조회</a></li>
+<li><a href="#_회원가입_시_일반_멤버_정보_입력">6.4. 회원가입 시 일반 멤버 정보 입력</a></li>
+<li><a href="#_회원가입_시_싸피_멤버_정보_입력">6.5. 회원가입 시 싸피 멤버 정보 입력</a></li>
+<li><a href="#_싸피생_인증">6.6. 싸피생 인증</a></li>
+<li><a href="#_나의_포트폴리오_조회">6.7. 나의 포트폴리오 조회</a></li>
+<li><a href="#_다른_멤버_포트폴리오_조회">6.8. 다른 멤버 포트폴리오 조회</a></li>
+<li><a href="#_멤버_포트폴리오_수정">6.9. 멤버 포트폴리오 수정</a></li>
+<li><a href="#_멤버의_기본_정보_조회">6.10. 멤버의 기본 정보 조회</a></li>
+<li><a href="#_멤버의_기본_정보_수정">6.11. 멤버의 기본 정보 수정</a></li>
+<li><a href="#_나의_프로필_공개_여부_조회">6.12. 나의 프로필 공개 여부 조회</a></li>
+<li><a href="#_다른_멤버의_프로필_공개_여부_조회">6.13. 다른 멤버의 프로필 공개 여부 조회</a></li>
+<li><a href="#_프로필_공개_여부_수정">6.14. 프로필 공개 여부 수정</a></li>
+<li><a href="#_닉네임_중복_검사">6.15. 닉네임 중복 검사</a></li>
+<li><a href="#_닉네임_변경">6.16. 닉네임 변경</a></li>
+<li><a href="#_멤버의_전공자_여부_수정">6.17. 멤버의 전공자 여부 수정</a></li>
+<li><a href="#_멤버의_전공트랙_수정">6.18. 멤버의 전공트랙 수정</a></li>
 </ul>
 </li>
-<li><a href="#_이미지_업로드">7. 이미지 업로드</a>
+<li><a href="#_점심">7. 점심</a>
 <ul class="sectlevel2">
-<li><a href="#_이미지_업로드_url_요청">7.1. 이미지 업로드 URL 요청</a></li>
+<li><a href="#_점심_목록_조회">7.1. 점심 목록 조회</a></li>
+<li><a href="#_점심_상세_조회">7.2. 점심 상세 조회</a></li>
+<li><a href="#_점심_투표하기">7.3. 점심 투표하기</a></li>
+<li><a href="#_점심_투표_취소하기">7.4. 점심 투표 취소하기</a></li>
+</ul>
+</li>
+<li><a href="#_리크루트">8. 리크루트</a>
+<ul class="sectlevel2">
+<li><a href="#_리크루트_등록">8.1. 리크루트 등록</a></li>
+<li><a href="#_리크루트_스크랩_토글">8.2. 리크루트 스크랩 토글</a></li>
+<li><a href="#_리크루트_완료">8.3. 리크루트 완료</a></li>
+<li><a href="#_리크루트_상세_조회">8.4. 리크루트 상세 조회</a></li>
+<li><a href="#_리크루트_업데이트">8.5. 리크루트 업데이트</a></li>
+<li><a href="#_리크루트_삭제">8.6. 리크루트 삭제</a></li>
+<li><a href="#_리크루트_목록_조회_2">8.7. 리크루트 목록 조회</a></li>
+</ul>
+</li>
+<li><a href="#_리크루트_참여_신청">9. 리크루트 참여 신청</a>
+<ul class="sectlevel2">
+<li><a href="#_리크루트_참여_신청_2">9.1. 리크루트 참여 신청</a></li>
+<li><a href="#_리크루트_등록자_참여_신청_수락">9.2. 리크루트 등록자 참여 신청 수락</a></li>
+<li><a href="#_리크루트_신청자_참여_확정">9.3. 리크루트 신청자 참여 확정</a></li>
+<li><a href="#_리크루트_참여_신청_거절">9.4. 리크루트 참여 신청 거절</a></li>
+<li><a href="#_리크루트_신청자_참여_신청_취소">9.5. 리크루트 신청자 참여 신청 취소</a></li>
+<li><a href="#_리크루트_참여자_목록_조회">9.6. 리크루트 참여자 목록 조회</a></li>
+<li><a href="#_등록자_리크루트_참여신청_목록_조회">9.7. 등록자 리크루트 참여신청 목록 조회"</a></li>
+<li><a href="#_등록자_리크루트_참여신청_좋아요">9.8. 등록자 리크루트 참여신청 좋아요"</a></li>
+<li><a href="#_등록자_리크루트_참여신청_상세_조회">9.9. 등록자 리크루트 참여신청 상세 조회</a></li>
+</ul>
+</li>
+<li><a href="#_리크루트_덧글">10. 리크루트 덧글</a>
+<ul class="sectlevel2">
+<li><a href="#_리크루트_덧글_등록">10.1. 리크루트 덧글 등록</a></li>
+<li><a href="#_리크루트_덧글_삭제">10.2. 리크루트 덧글 삭제</a></li>
+<li><a href="#_리크루트_덧글_업데이트">10.3. 리크루트 덧글 업데이트</a></li>
+<li><a href="#_리크루트_덧글_좋아요">10.4. 리크루트 덧글 좋아요</a></li>
+<li><a href="#_리크루트_덧글_목록_조회">10.5. 리크루트 덧글 목록 조회</a></li>
+</ul>
+</li>
+<li><a href="#_이미지_업로드">11. 이미지 업로드</a>
+<ul class="sectlevel2">
+<li><a href="#_이미지_업로드_url_요청">11.1. 이미지 업로드 URL 요청</a></li>
 </ul>
 </li>
 </ul>
@@ -585,21 +640,100 @@ use of HTTP status codes.</p>
 <h3 id="_게시판_목록_조회"><a class="link" href="#_게시판_목록_조회">3.1. 게시판 목록 조회</a></h3>
 <div class="sect3">
 <h4 id="_게시판_목록_조회_http_request"><a class="link" href="#_게시판_목록_조회_http_request">3.1.1. HTTP request</a></h4>
-<div class="paragraph">
-<p>Snippet http-request not found for operation::board-controller-test/find-boards</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /boards HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_게시판_목록_조회_http_response"><a class="link" href="#_게시판_목록_조회_http_response">3.1.2. HTTP response</a></h4>
-<div class="paragraph">
-<p>Snippet http-response not found for operation::board-controller-test/find-boards</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 412
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "boards" : [ {
+      "boardId" : 1,
+      "title" : "자유 게시판",
+      "imageUrl" : "IMAGE URL",
+      "description" : "자유롭게 떠드는 공간입니다."
+    }, {
+      "boardId" : 2,
+      "title" : "취업 게시판",
+      "imageUrl" : "IMAGE URL",
+      "description" : "취업에 대한 정보를 공유해보세요."
+    } ]
+  }
+}</code></pre>
+</div>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_게시판_목록_조회_response_fields"><a class="link" href="#_게시판_목록_조회_response_fields">3.1.3. Response fields</a></h4>
-<div class="paragraph">
-<p>Snippet response-fields not found for operation::board-controller-test/find-boards</p>
-</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boards</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boards[].boardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 목록의 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boards[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 목록의 제목, 자유 게시판 | 취업 게시판 | 맛집 게시판 | 질문 게시판 | 싸피 예비생 게시판</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boards[].imageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판 배너 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.boards[].description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시판의 특성을 설명해주는 설명문</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 </div>
@@ -1028,8 +1162,8 @@ Host: api.ssafsound.com
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Set-Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Max-Age=2629744; Expires=Thu, 14 Sep 2023 20:25:54 GMT; Secure; HttpOnly
-Set-Cookie: refreshToken=syJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IsdfserwetweSflKxwRJeSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Max-Age=2629744; Expires=Thu, 14 Sep 2023 20:25:54 GMT; Secure; HttpOnly
+Set-Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Max-Age=2629744; Expires=Wed, 20 Sep 2023 21:11:59 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=syJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IsdfserwetweSflKxwRJeSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Max-Age=2629744; Expires=Wed, 20 Sep 2023 21:11:59 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 415
 
@@ -1247,12 +1381,2443 @@ Content-Length: 241
 </div>
 </div>
 <div class="sect1">
-<h2 id="_점심"><a class="link" href="#_점심">6. 점심</a></h2>
+<h2 id="_멤버"><a class="link" href="#_멤버">6. 멤버</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_점심_목록_조회"><a class="link" href="#_점심_목록_조회">6.1. 점심 목록 조회</a></h3>
+<h3 id="_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다"><a class="link" href="#_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다">6.1. 소셜 로그인 후 멤버를 조회 했을때, 나갈 수 있기 때문에 ssafyMember가 null 이라면 회원가입을 진행해야 합니다.</a></h3>
 <div class="sect3">
-<h4 id="_점심_목록_조회_http_request"><a class="link" href="#_점심_목록_조회_http_request">6.1.1. HTTP request</a></h4>
+<h4 id="_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_cookie"><a class="link" href="#_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_cookie">6.1.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_http_request"><a class="link" href="#_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_http_request">6.1.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_http_response"><a class="link" href="#_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_http_response">6.1.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 204
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "memberId" : 1,
+    "memberRole" : "user",
+    "nickname" : null,
+    "ssafyMember" : null,
+    "isMajor" : null,
+    "ssafyInfo" : null
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_response_fields"><a class="link" href="#_소셜_로그인_후_멤버를_조회_했을때_나갈_수_있기_때문에_ssafymember가_null_이라면_회원가입을_진행해야_합니다_response_fields">6.1.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberRole</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 권한</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 정보</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_일반_멤버_정보_조회"><a class="link" href="#_일반_멤버_정보_조회">6.2. 일반 멤버 정보 조회</a></h3>
+<div class="sect3">
+<h4 id="_일반_멤버_정보_조회_cookie"><a class="link" href="#_일반_멤버_정보_조회_cookie">6.2.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_일반_멤버_정보_조회_http_request"><a class="link" href="#_일반_멤버_정보_조회_http_request">6.2.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_일반_멤버_정보_조회_http_response"><a class="link" href="#_일반_멤버_정보_조회_http_response">6.2.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 208
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "memberId" : 1,
+    "memberRole" : "user",
+    "nickname" : "james",
+    "ssafyMember" : false,
+    "isMajor" : true,
+    "ssafyInfo" : null
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_일반_멤버_정보_조회_response_fields"><a class="link" href="#_일반_멤버_정보_조회_response_fields">6.2.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberRole</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 권한</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 정보 NULL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_싸피생_멤버_정보_조회"><a class="link" href="#_싸피생_멤버_정보_조회">6.3. 싸피생 멤버 정보 조회</a></h3>
+<div class="sect3">
+<h4 id="_싸피생_멤버_정보_조회_cookie"><a class="link" href="#_싸피생_멤버_정보_조회_cookie">6.3.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_싸피생_멤버_정보_조회_http_request"><a class="link" href="#_싸피생_멤버_정보_조회_http_request">6.3.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_싸피생_멤버_정보_조회_http_response"><a class="link" href="#_싸피생_멤버_정보_조회_http_response">6.3.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 328
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "memberId" : 1,
+    "memberRole" : "user",
+    "nickname" : "paul",
+    "ssafyMember" : true,
+    "isMajor" : true,
+    "ssafyInfo" : {
+      "semester" : 9,
+      "campus" : "서울",
+      "certificationState" : "CERTIFIED",
+      "majorTrack" : "Java"
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_싸피생_멤버_정보_조회_response_fields"><a class="link" href="#_싸피생_멤버_정보_조회_response_fields">6.3.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberRole</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 권한</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피 기수 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">캠퍼스 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피생 인증상태(CERTIFIED/UNCERTIFIED)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공 트랙(인증상태가 UNCERTIFIED라면 NULL)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_회원가입_시_일반_멤버_정보_입력"><a class="link" href="#_회원가입_시_일반_멤버_정보_입력">6.4. 회원가입 시 일반 멤버 정보 입력</a></h3>
+<div class="sect3">
+<h4 id="_회원가입_시_일반_멤버_정보_입력_cookie"><a class="link" href="#_회원가입_시_일반_멤버_정보_입력_cookie">6.4.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_일반_멤버_정보_입력_http_request"><a class="link" href="#_회원가입_시_일반_멤버_정보_입력_http_request">6.4.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /members HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 111
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "nickname" : "james",
+  "ssafyMember" : false,
+  "isMajor" : true,
+  "semester" : null,
+  "campus" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_일반_멤버_정보_입력_request_body"><a class="link" href="#_회원가입_시_일반_멤버_정보_입력_request_body">6.4.3. Request body</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "nickname" : "james",
+  "ssafyMember" : false,
+  "isMajor" : true,
+  "semester" : null,
+  "campus" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_일반_멤버_정보_입력_request_fields"><a class="link" href="#_회원가입_시_일반_멤버_정보_입력_request_fields">6.4.4. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피 기수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">캠퍼스 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_일반_멤버_정보_입력_http_response"><a class="link" href="#_회원가입_시_일반_멤버_정보_입력_http_response">6.4.5. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 208
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "memberId" : 1,
+    "memberRole" : "user",
+    "nickname" : "james",
+    "ssafyMember" : false,
+    "isMajor" : true,
+    "ssafyInfo" : null
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_일반_멤버_정보_입력_response_fields"><a class="link" href="#_회원가입_시_일반_멤버_정보_입력_response_fields">6.4.6. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberRole</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 권한</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피 기수 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">캠퍼스 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피생 인증상태(CERTIFIED/UNCERTIFIED)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공 트랙(인증상태가 UNCERTIFIED라면 NULL)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_회원가입_시_싸피_멤버_정보_입력"><a class="link" href="#_회원가입_시_싸피_멤버_정보_입력">6.5. 회원가입 시 싸피 멤버 정보 입력</a></h3>
+<div class="sect3">
+<h4 id="_회원가입_시_싸피_멤버_정보_입력_cookie"><a class="link" href="#_회원가입_시_싸피_멤버_정보_입력_cookie">6.5.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_싸피_멤버_정보_입력_http_request"><a class="link" href="#_회원가입_시_싸피_멤버_정보_입력_http_request">6.5.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /members HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 111
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "nickname" : "james",
+  "ssafyMember" : true,
+  "isMajor" : true,
+  "semester" : 9,
+  "campus" : "서울"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_싸피_멤버_정보_입력_request_body"><a class="link" href="#_회원가입_시_싸피_멤버_정보_입력_request_body">6.5.3. Request body</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "nickname" : "james",
+  "ssafyMember" : true,
+  "isMajor" : true,
+  "semester" : 9,
+  "campus" : "서울"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_싸피_멤버_정보_입력_request_fields"><a class="link" href="#_회원가입_시_싸피_멤버_정보_입력_request_fields">6.5.4. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피 기수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">캠퍼스 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_싸피_멤버_정보_입력_http_response"><a class="link" href="#_회원가입_시_싸피_멤버_정보_입력_http_response">6.5.5. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 329
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "memberId" : 1,
+    "memberRole" : "user",
+    "nickname" : "james",
+    "ssafyMember" : true,
+    "isMajor" : true,
+    "ssafyInfo" : {
+      "semester" : 9,
+      "campus" : "서울",
+      "certificationState" : "UNCERTIFIED",
+      "majorTrack" : null
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_회원가입_시_싸피_멤버_정보_입력_response_fields"><a class="link" href="#_회원가입_시_싸피_멤버_정보_입력_response_fields">6.5.6. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberRole</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 권한</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피 기수 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">캠퍼스 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피생 인증상태(CERTIFIED/UNCERTIFIED)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공 트랙(인증상태가 UNCERTIFIED라면 NULL)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_싸피생_인증"><a class="link" href="#_싸피생_인증">6.6. 싸피생 인증</a></h3>
+<div class="sect3">
+<h4 id="_싸피생_인증_cookie"><a class="link" href="#_싸피생_인증_cookie">6.6.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_싸피생_인증_http_request"><a class="link" href="#_싸피생_인증_http_request">6.6.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/ssafy-certification HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 67
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "majorTrack" : "Java",
+  "semester" : 9,
+  "answer" : "great"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_싸피생_인증_request_fields"><a class="link" href="#_싸피생_인증_request_fields">6.6.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공트랙</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">기수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>answer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">기수에 따른 출제 문제에 대한 정답</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_싸피생_인증_http_response"><a class="link" href="#_싸피생_인증_http_response">6.6.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 122
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "possible" : true,
+    "certificationInquiryCount" : 3
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_싸피생_인증_response_fields"><a class="link" href="#_싸피생_인증_response_fields">6.6.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.possible</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증 상태 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.certificationInquiryCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증 시도 횟수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_나의_포트폴리오_조회"><a class="link" href="#_나의_포트폴리오_조회">6.7. 나의 포트폴리오 조회</a></h3>
+<div class="sect3">
+<h4 id="_나의_포트폴리오_조회_cookie"><a class="link" href="#_나의_포트폴리오_조회_cookie">6.7.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_나의_포트폴리오_조회_http_request"><a class="link" href="#_나의_포트폴리오_조회_http_request">6.7.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/portfolio HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_나의_포트폴리오_조회_http_response"><a class="link" href="#_나의_포트폴리오_조회_http_response">6.7.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 380
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "portfolioElement" : {
+      "selfIntroduction" : "안녕하세요! 반가워요.",
+      "skills" : [ "Java", "Android" ],
+      "memberLinks" : [ {
+        "linkName" : "velog",
+        "path" : "http://test-link1"
+      }, {
+        "linkName" : "t-story",
+        "path" : "http://test-link2"
+      } ]
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_나의_포트폴리오_조회_response_fields"><a class="link" href="#_나의_포트폴리오_조회_response_fields">6.7.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.selfIntroduction</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 소개 글</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.skills</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 기술 스택들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.memberLinks</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 소개 링크들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.memberLinks[].linkName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버의 소개 링크 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.memberLinks[].path</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버의 소개 링크 경로</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_다른_멤버_포트폴리오_조회"><a class="link" href="#_다른_멤버_포트폴리오_조회">6.8. 다른 멤버 포트폴리오 조회</a></h3>
+<div class="sect3">
+<h4 id="_다른_멤버_포트폴리오_조회_cookie"><a class="link" href="#_다른_멤버_포트폴리오_조회_cookie">6.8.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 불필요</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버_포트폴리오_조회_http_request"><a class="link" href="#_다른_멤버_포트폴리오_조회_http_request">6.8.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/99/portfolio HTTP/1.1
+Host: api.ssafsound.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버_포트폴리오_조회_path_parameters"><a class="link" href="#_다른_멤버_포트폴리오_조회_path_parameters">6.8.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /members/{memberId}/portfolio</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 Id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버_포트폴리오_조회_http_response"><a class="link" href="#_다른_멤버_포트폴리오_조회_http_response">6.8.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 380
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "portfolioElement" : {
+      "selfIntroduction" : "안녕하세요! 반가워요.",
+      "skills" : [ "Java", "Android" ],
+      "memberLinks" : [ {
+        "linkName" : "velog",
+        "path" : "http://test-link1"
+      }, {
+        "linkName" : "t-story",
+        "path" : "http://test-link2"
+      } ]
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버_포트폴리오_조회_response_fields"><a class="link" href="#_다른_멤버_포트폴리오_조회_response_fields">6.8.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.selfIntroduction</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 소개 글</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.skills</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 기술 스택들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.memberLinks</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 소개 링크들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.memberLinks[].linkName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버의 소개 링크 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.portfolioElement.memberLinks[].path</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버의 소개 링크 경로</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_멤버_포트폴리오_수정"><a class="link" href="#_멤버_포트폴리오_수정">6.9. 멤버 포트폴리오 수정</a></h3>
+<div class="sect3">
+<h4 id="_멤버_포트폴리오_수정_cookie"><a class="link" href="#_멤버_포트폴리오_수정_cookie">6.9.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버_포트폴리오_수정_http_request"><a class="link" href="#_멤버_포트폴리오_수정_http_request">6.9.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /members/portfolio HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 258
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "selfIntroduction" : "안녕하세요 자기소개합니다.",
+  "skills" : [ "Java", "Spring" ],
+  "memberLinks" : [ {
+    "linkName" : "velog",
+    "path" : "http://test-link1"
+  }, {
+    "linkName" : "t-story",
+    "path" : "http://test-link2"
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버_포트폴리오_수정_request_fields"><a class="link" href="#_멤버_포트폴리오_수정_request_fields">6.9.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>selfIntroduction</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">자기소개</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>skills[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">기술 스택들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberLinks[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">소개 링크들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberLinks[].linkName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">링크 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberLinks[].path</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">링크 경로</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버_포트폴리오_수정_http_response"><a class="link" href="#_멤버_포트폴리오_수정_http_response">6.9.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버_포트폴리오_수정_response_fields"><a class="link" href="#_멤버_포트폴리오_수정_response_fields">6.9.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_멤버의_기본_정보_조회"><a class="link" href="#_멤버의_기본_정보_조회">6.10. 멤버의 기본 정보 조회</a></h3>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_조회_cookie"><a class="link" href="#_멤버의_기본_정보_조회_cookie">6.10.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 불필요</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_조회_http_request"><a class="link" href="#_멤버의_기본_정보_조회_http_request">6.10.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/99/default-information HTTP/1.1
+Host: api.ssafsound.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_조회_path_parameters"><a class="link" href="#_멤버의_기본_정보_조회_path_parameters">6.10.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /members/{memberId}/default-information</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 Id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_조회_http_response"><a class="link" href="#_멤버의_기본_정보_조회_http_response">6.10.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 282
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "nickname" : "james",
+    "ssafyMember" : true,
+    "isMajor" : true,
+    "ssafyInfo" : {
+      "semester" : 9,
+      "campus" : "서울",
+      "certificationState" : "CERTIFIED",
+      "majorTrack" : "Java"
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_조회_response_fields"><a class="link" href="#_멤버의_기본_정보_조회_response_fields">6.10.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피 기수 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">캠퍼스 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피생 인증상태(CERTIFIED/UNCERTIFIED)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공 트랙(인증상태가 UNCERTIFIED라면 NULL)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_멤버의_기본_정보_수정"><a class="link" href="#_멤버의_기본_정보_수정">6.11. 멤버의 기본 정보 수정</a></h3>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_수정_cookie"><a class="link" href="#_멤버의_기본_정보_수정_cookie">6.11.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_수정_http_request"><a class="link" href="#_멤버의_기본_정보_수정_http_request">6.11.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/default-information HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 67
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "ssafyMember" : false,
+  "semester" : null,
+  "campus" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_수정_request_fields"><a class="link" href="#_멤버의_기본_정보_수정_request_fields">6.11.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피인 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">기수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">캠퍼스</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_수정_http_response"><a class="link" href="#_멤버의_기본_정보_수정_http_response">6.11.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_기본_정보_수정_response_fields"><a class="link" href="#_멤버의_기본_정보_수정_response_fields">6.11.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_나의_프로필_공개_여부_조회"><a class="link" href="#_나의_프로필_공개_여부_조회">6.12. 나의 프로필 공개 여부 조회</a></h3>
+<div class="sect3">
+<h4 id="_나의_프로필_공개_여부_조회_cookie"><a class="link" href="#_나의_프로필_공개_여부_조회_cookie">6.12.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_나의_프로필_공개_여부_조회_http_request"><a class="link" href="#_나의_프로필_공개_여부_조회_http_request">6.12.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/public-profile HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_나의_프로필_공개_여부_조회_http_response"><a class="link" href="#_나의_프로필_공개_여부_조회_http_response">6.12.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 85
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "isPublic" : true
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_나의_프로필_공개_여부_조회_response_fields"><a class="link" href="#_나의_프로필_공개_여부_조회_response_fields">6.12.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isPublic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 공개 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_다른_멤버의_프로필_공개_여부_조회"><a class="link" href="#_다른_멤버의_프로필_공개_여부_조회">6.13. 다른 멤버의 프로필 공개 여부 조회</a></h3>
+<div class="sect3">
+<h4 id="_다른_멤버의_프로필_공개_여부_조회_cookie"><a class="link" href="#_다른_멤버의_프로필_공개_여부_조회_cookie">6.13.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 불필요</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버의_프로필_공개_여부_조회_http_request"><a class="link" href="#_다른_멤버의_프로필_공개_여부_조회_http_request">6.13.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/99/public-profile HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버의_프로필_공개_여부_조회_path_parameters"><a class="link" href="#_다른_멤버의_프로필_공개_여부_조회_path_parameters">6.13.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /members/{memberId}/public-profile</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 Id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버의_프로필_공개_여부_조회_http_response"><a class="link" href="#_다른_멤버의_프로필_공개_여부_조회_http_response">6.13.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 85
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "isPublic" : true
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_다른_멤버의_프로필_공개_여부_조회_response_fields"><a class="link" href="#_다른_멤버의_프로필_공개_여부_조회_response_fields">6.13.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isPublic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 공개 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_프로필_공개_여부_수정"><a class="link" href="#_프로필_공개_여부_수정">6.14. 프로필 공개 여부 수정</a></h3>
+<div class="sect3">
+<h4 id="_프로필_공개_여부_수정_cookie"><a class="link" href="#_프로필_공개_여부_수정_cookie">6.14.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_프로필_공개_여부_수정_http_request"><a class="link" href="#_프로필_공개_여부_수정_http_request">6.14.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/public-profile HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 24
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "isPublic" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_프로필_공개_여부_수정_request_fields"><a class="link" href="#_프로필_공개_여부_수정_request_fields">6.14.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isPublic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 공개 여부 수정</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_프로필_공개_여부_수정_http_response"><a class="link" href="#_프로필_공개_여부_수정_http_response">6.14.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_프로필_공개_여부_수정_response_fields"><a class="link" href="#_프로필_공개_여부_수정_response_fields">6.14.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_중복_검사"><a class="link" href="#_닉네임_중복_검사">6.15. 닉네임 중복 검사</a></h3>
+<div class="sect3">
+<h4 id="_닉네임_중복_검사_cookie"><a class="link" href="#_닉네임_중복_검사_cookie">6.15.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 불필요</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_중복_검사_http_request"><a class="link" href="#_닉네임_중복_검사_http_request">6.15.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/nickname HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 26
+Host: api.ssafsound.com
+
+{
+  "nickname" : "james"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_중복_검사_request_fields"><a class="link" href="#_닉네임_중복_검사_request_fields">6.15.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_중복_검사_http_response"><a class="link" href="#_닉네임_중복_검사_http_response">6.15.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 85
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "possible" : true
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_중복_검사_response_fields"><a class="link" href="#_닉네임_중복_검사_response_fields">6.15.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.possible</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임 사용 가능 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_변경"><a class="link" href="#_닉네임_변경">6.16. 닉네임 변경</a></h3>
+<div class="sect3">
+<h4 id="_닉네임_변경_cookie"><a class="link" href="#_닉네임_변경_cookie">6.16.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_변경_http_request"><a class="link" href="#_닉네임_변경_http_request">6.16.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/nickname HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 26
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "nickname" : "james"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_변경_request_fields"><a class="link" href="#_닉네임_변경_request_fields">6.16.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_변경_http_response"><a class="link" href="#_닉네임_변경_http_response">6.16.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_닉네임_변경_response_fields"><a class="link" href="#_닉네임_변경_response_fields">6.16.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_멤버의_전공자_여부_수정"><a class="link" href="#_멤버의_전공자_여부_수정">6.17. 멤버의 전공자 여부 수정</a></h3>
+<div class="sect3">
+<h4 id="_멤버의_전공자_여부_수정_cookie"><a class="link" href="#_멤버의_전공자_여부_수정_cookie">6.17.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공자_여부_수정_http_request"><a class="link" href="#_멤버의_전공자_여부_수정_http_request">6.17.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/major HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 23
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "isMajor" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공자_여부_수정_request_fields"><a class="link" href="#_멤버의_전공자_여부_수정_request_fields">6.17.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자유무</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공자_여부_수정_http_response"><a class="link" href="#_멤버의_전공자_여부_수정_http_response">6.17.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공자_여부_수정_response_fields"><a class="link" href="#_멤버의_전공자_여부_수정_response_fields">6.17.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_멤버의_전공트랙_수정"><a class="link" href="#_멤버의_전공트랙_수정">6.18. 멤버의 전공트랙 수정</a></h3>
+<div class="sect3">
+<h4 id="_멤버의_전공트랙_수정_cookie"><a class="link" href="#_멤버의_전공트랙_수정_cookie">6.18.1. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공트랙_수정_http_request"><a class="link" href="#_멤버의_전공트랙_수정_http_request">6.18.2. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/major-track HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 31
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "majorTrack" : "Embedded"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공트랙_수정_request_fields"><a class="link" href="#_멤버의_전공트랙_수정_request_fields">6.18.3. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공트랙("Embedded" , "Python" , "Java" , "Mobile")</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공트랙_수정_http_response"><a class="link" href="#_멤버의_전공트랙_수정_http_response">6.18.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_멤버의_전공트랙_수정_response_fields"><a class="link" href="#_멤버의_전공트랙_수정_response_fields">6.18.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_점심"><a class="link" href="#_점심">7. 점심</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_점심_목록_조회"><a class="link" href="#_점심_목록_조회">7.1. 점심 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_점심_목록_조회_http_request"><a class="link" href="#_점심_목록_조회_http_request">7.1.1. HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /lunch?campus=%EC%84%9C%EC%9A%B8&amp;date=2023-08-12 HTTP/1.1
@@ -1262,7 +3827,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_목록_조회_cookie"><a class="link" href="#_점심_목록_조회_cookie">6.1.2. Cookie</a></h4>
+<h4 id="_점심_목록_조회_cookie"><a class="link" href="#_점심_목록_조회_cookie">7.1.2. Cookie</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1283,7 +3848,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_목록_조회_request_parameters"><a class="link" href="#_점심_목록_조회_request_parameters">6.1.3. Request parameters</a></h4>
+<h4 id="_점심_목록_조회_request_parameters"><a class="link" href="#_점심_목록_조회_request_parameters">7.1.3. Request parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1308,7 +3873,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_목록_조회_http_response"><a class="link" href="#_점심_목록_조회_http_response">6.1.4. HTTP response</a></h4>
+<h4 id="_점심_목록_조회_http_response"><a class="link" href="#_점심_목록_조회_http_response">7.1.4. HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1343,7 +3908,7 @@ Content-Length: 706
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_목록_조회_response_fields"><a class="link" href="#_점심_목록_조회_response_fields">6.1.5. Response fields</a></h4>
+<h4 id="_점심_목록_조회_response_fields"><a class="link" href="#_점심_목록_조회_response_fields">7.1.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1413,9 +3978,9 @@ Content-Length: 706
 </div>
 </div>
 <div class="sect2">
-<h3 id="_점심_상세_조회"><a class="link" href="#_점심_상세_조회">6.2. 점심 상세 조회</a></h3>
+<h3 id="_점심_상세_조회"><a class="link" href="#_점심_상세_조회">7.2. 점심 상세 조회</a></h3>
 <div class="sect3">
-<h4 id="_점심_상세_조회_http_request"><a class="link" href="#_점심_상세_조회_http_request">6.2.1. HTTP request</a></h4>
+<h4 id="_점심_상세_조회_http_request"><a class="link" href="#_점심_상세_조회_http_request">7.2.1. HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /lunch/1 HTTP/1.1
@@ -1424,7 +3989,7 @@ Host: api.ssafsound.com</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_상세_조회_cookie"><a class="link" href="#_점심_상세_조회_cookie">6.2.2. Cookie</a></h4>
+<h4 id="_점심_상세_조회_cookie"><a class="link" href="#_점심_상세_조회_cookie">7.2.2. Cookie</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1445,7 +4010,7 @@ Host: api.ssafsound.com</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_상세_조회_path_parameters"><a class="link" href="#_점심_상세_조회_path_parameters">6.2.3. Path parameters</a></h4>
+<h4 id="_점심_상세_조회_path_parameters"><a class="link" href="#_점심_상세_조회_path_parameters">7.2.3. Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 1. /lunch/{lunchId}</caption>
 <colgroup>
@@ -1467,7 +4032,7 @@ Host: api.ssafsound.com</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_상세_조회_http_response"><a class="link" href="#_점심_상세_조회_http_response">6.2.4. HTTP response</a></h4>
+<h4 id="_점심_상세_조회_http_response"><a class="link" href="#_점심_상세_조회_http_response">7.2.4. HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1487,7 +4052,7 @@ Content-Length: 173
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_상세_조회_response_fields"><a class="link" href="#_점심_상세_조회_response_fields">6.2.5. Response fields</a></h4>
+<h4 id="_점심_상세_조회_response_fields"><a class="link" href="#_점심_상세_조회_response_fields">7.2.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1537,9 +4102,9 @@ Content-Length: 173
 </div>
 </div>
 <div class="sect2">
-<h3 id="_점심_투표하기"><a class="link" href="#_점심_투표하기">6.3. 점심 투표하기</a></h3>
+<h3 id="_점심_투표하기"><a class="link" href="#_점심_투표하기">7.3. 점심 투표하기</a></h3>
 <div class="sect3">
-<h4 id="_점심_투표하기_http_request"><a class="link" href="#_점심_투표하기_http_request">6.3.1. HTTP request</a></h4>
+<h4 id="_점심_투표하기_http_request"><a class="link" href="#_점심_투표하기_http_request">7.3.1. HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /lunch/poll/2 HTTP/1.1
@@ -1549,7 +4114,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표하기_cookie"><a class="link" href="#_점심_투표하기_cookie">6.3.2. Cookie</a></h4>
+<h4 id="_점심_투표하기_cookie"><a class="link" href="#_점심_투표하기_cookie">7.3.2. Cookie</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1570,7 +4135,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표하기_path_parameters"><a class="link" href="#_점심_투표하기_path_parameters">6.3.3. Path parameters</a></h4>
+<h4 id="_점심_투표하기_path_parameters"><a class="link" href="#_점심_투표하기_path_parameters">7.3.3. Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 1. /lunch/poll/{lunchId}</caption>
 <colgroup>
@@ -1592,7 +4157,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표하기_http_response"><a class="link" href="#_점심_투표하기_http_response">6.3.4. HTTP response</a></h4>
+<h4 id="_점심_투표하기_http_response"><a class="link" href="#_점심_투표하기_http_response">7.3.4. HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1610,7 +4175,7 @@ Content-Length: 86
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표하기_response_fields"><a class="link" href="#_점심_투표하기_response_fields">6.3.5. Response fields</a></h4>
+<h4 id="_점심_투표하기_response_fields"><a class="link" href="#_점심_투표하기_response_fields">7.3.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1650,9 +4215,9 @@ Content-Length: 86
 </div>
 </div>
 <div class="sect2">
-<h3 id="_점심_투표_취소하기"><a class="link" href="#_점심_투표_취소하기">6.4. 점심 투표 취소하기</a></h3>
+<h3 id="_점심_투표_취소하기"><a class="link" href="#_점심_투표_취소하기">7.4. 점심 투표 취소하기</a></h3>
 <div class="sect3">
-<h4 id="_점심_투표_취소하기_http_request"><a class="link" href="#_점심_투표_취소하기_http_request">6.4.1. HTTP request</a></h4>
+<h4 id="_점심_투표_취소하기_http_request"><a class="link" href="#_점심_투표_취소하기_http_request">7.4.1. HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /lunch/poll/revert/2 HTTP/1.1
@@ -1662,7 +4227,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표_취소하기_cookie"><a class="link" href="#_점심_투표_취소하기_cookie">6.4.2. Cookie</a></h4>
+<h4 id="_점심_투표_취소하기_cookie"><a class="link" href="#_점심_투표_취소하기_cookie">7.4.2. Cookie</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1683,7 +4248,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표_취소하기_path_parameters"><a class="link" href="#_점심_투표_취소하기_path_parameters">6.4.3. Path parameters</a></h4>
+<h4 id="_점심_투표_취소하기_path_parameters"><a class="link" href="#_점심_투표_취소하기_path_parameters">7.4.3. Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 1. /lunch/poll/revert/{lunchId}</caption>
 <colgroup>
@@ -1705,7 +4270,7 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표_취소하기_http_response"><a class="link" href="#_점심_투표_취소하기_http_response">6.4.4. HTTP response</a></h4>
+<h4 id="_점심_투표_취소하기_http_response"><a class="link" href="#_점심_투표_취소하기_http_response">7.4.4. HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1723,7 +4288,7 @@ Content-Length: 86
 </div>
 </div>
 <div class="sect3">
-<h4 id="_점심_투표_취소하기_response_fields"><a class="link" href="#_점심_투표_취소하기_response_fields">6.4.5. Response fields</a></h4>
+<h4 id="_점심_투표_취소하기_response_fields"><a class="link" href="#_점심_투표_취소하기_response_fields">7.4.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1765,22 +4330,115 @@ Content-Length: 86
 </div>
 </div>
 <div class="sect1">
-<h2 id="_이미지_업로드"><a class="link" href="#_이미지_업로드">7. 이미지 업로드</a></h2>
+<h2 id="_리크루트"><a class="link" href="#_리크루트">8. 리크루트</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_이미지_업로드_url_요청"><a class="link" href="#_이미지_업로드_url_요청">7.1. 이미지 업로드 URL 요청</a></h3>
+<h3 id="_리크루트_등록"><a class="link" href="#_리크루트_등록">8.1. 리크루트 등록</a></h3>
 <div class="sect3">
-<h4 id="_이미지_업로드_url_요청_http_request"><a class="link" href="#_이미지_업로드_url_요청_http_request">7.1.1. HTTP request</a></h4>
+<h4 id="_리크루트_등록_http_request"><a class="link" href="#_리크루트_등록_http_request">8.1.1. HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /store/image HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /recruits HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 1238
 Host: api.ssafsound.com
-Cookie: accessToken=accessTokenValue</code></pre>
+Cookie: accessToken=accessTokenValue
+
+{
+  "category" : "PROJECT",
+  "recruitEnd" : "2023-08-28",
+  "title" : "[사이드 프로젝트] 공모전 레퍼런스 웹 플랫폼 개발 프로젝트 팀원을 모집합니다.",
+  "content" : "&lt;p&gt;[프로젝트 소개]&lt;/p&gt;\n저희 프로젝트는 대학생들의 공모전 경험에 있어 누구나 참고할 레퍼런스를 제공받고, 또 자발적으로 공유할 수 있는 환경을 구축하고자 시작하게 되었습니다! 저희 프로젝트는 아래와 같은 특징을 가지고 있습니다.\n현재 PM 1명, 프론트엔드 개발자 2명, 백엔드 개발자 1명이 있으며, 디자인의 경우 PM이 1차 MVP의 UI/UX를 제작했습니다.\n",
+  "contactURI" : "https://open.kakao.com/o/sA8Kb83b",
+  "registerRecruitType" : "백엔드",
+  "skills" : [ "Spring", "React", "IOS", "Vue", "Java", "JavaScript", "TypeScript", "Nodejs", "Nextjs", "Nuxtjs", "XD", "Swift", "Figma", "Svelte", "Android", "Flutter", "Django", "기타" ],
+  "questions" : [ "프로젝트에 참여하고자 하는 동기가 무엇인가요?" ],
+  "limitations" : [ {
+    "recruitType" : "백엔드",
+    "limit" : 3
+  }, {
+    "recruitType" : "프론트엔드",
+    "limit" : 3
+  }, {
+    "recruitType" : "앱",
+    "limit" : 3
+  } ]
+}</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_이미지_업로드_url_요청_cookie"><a class="link" href="#_이미지_업로드_url_요청_cookie">7.1.2. Cookie</a></h4>
+<h4 id="_리크루트_등록_request_fields"><a class="link" href="#_리크루트_등록_request_fields">8.1.2. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PROJECT | STUDY</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitEnd</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd 모집 종료 일자, 당일 날짜 이후의 값으로만 설정 가능</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집글 제목, 글자 수 제한 50자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 본문, 글자 수 제한 3000자, html 포함 4000자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contactURI</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 작성자와 연락 가능한 오픈톡 링크</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>registerRecruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 작성자가 선택한 자신의 역할군, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>skills[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트와 연관된 기술 스택, 메타데이터-스킬 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questions[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참석자에게 할 질문, 1개만 등록 가능</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>limitations[].recruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>limitations[].limit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인원 제한 1명이상 10명 이하</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_등록_cookie"><a class="link" href="#_리크루트_등록_cookie">8.1.3. Cookie</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1801,7 +4459,2908 @@ Cookie: accessToken=accessTokenValue</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_이미지_업로드_url_요청_http_response"><a class="link" href="#_이미지_업로드_url_요청_http_response">7.1.3. HTTP response</a></h4>
+<h4 id="_리크루트_등록_http_response"><a class="link" href="#_리크루트_등록_http_response">8.1.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_등록_response_fields"><a class="link" href="#_리크루트_등록_response_fields">8.1.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_스크랩_토글"><a class="link" href="#_리크루트_스크랩_토글">8.2. 리크루트 스크랩 토글</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_스크랩_토글_http_request"><a class="link" href="#_리크루트_스크랩_토글_http_request">8.2.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /recruits/1/scrap HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_스크랩_토글_cookie"><a class="link" href="#_리크루트_스크랩_토글_cookie">8.2.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_스크랩_토글_path_parameters"><a class="link" href="#_리크루트_스크랩_토글_path_parameters">8.2.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}/scrap</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_스크랩_토글_http_response"><a class="link" href="#_리크루트_스크랩_토글_http_response">8.2.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 84
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "scrapCount" : 1
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_스크랩_토글_response_fields"><a class="link" href="#_리크루트_스크랩_토글_response_fields">8.2.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.scrapCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 스크랩 갯수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_완료"><a class="link" href="#_리크루트_완료">8.3. 리크루트 완료</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_완료_http_request"><a class="link" href="#_리크루트_완료_http_request">8.3.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /recruits/1/expired HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_완료_cookie"><a class="link" href="#_리크루트_완료_cookie">8.3.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_완료_path_parameters"><a class="link" href="#_리크루트_완료_path_parameters">8.3.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}/expired</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_완료_http_response"><a class="link" href="#_리크루트_완료_http_response">8.3.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_완료_response_fields"><a class="link" href="#_리크루트_완료_response_fields">8.3.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_상세_조회"><a class="link" href="#_리크루트_상세_조회">8.4. 리크루트 상세 조회</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_상세_조회_http_request"><a class="link" href="#_리크루트_상세_조회_http_request">8.4.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /recruits/1 HTTP/1.1
+Host: api.ssafsound.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_상세_조회_path_parameters"><a class="link" href="#_리크루트_상세_조회_path_parameters">8.4.2. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_상세_조회_http_response"><a class="link" href="#_리크루트_상세_조회_http_response">8.4.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 1437
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "recruitId" : 1,
+    "title" : "[사이드 프로젝트] 공모전 레퍼런스 웹 플랫폼 개발 프로젝트 팀원을 모집합니다.",
+    "content" : "&lt;p&gt;[프로젝트 소개]&lt;/p&gt;\n저희 프로젝트는 대학생들의 공모전 경험에 있어 누구나 참고할 레퍼런스를 제공받고, 또 자발적으로 공유할 수 있는 환경을 구축하고자 시작하게 되었습니다! 저희 프로젝트는 아래와 같은 특징을 가지고 있습니다.\n현재 PM 1명, 프론트엔드 개발자 2명, 백엔드 개발자 1명이 있으며, 디자인의 경우 PM이 1차 MVP의 UI/UX를 제작했습니다.\n",
+    "contactURI" : "https://open.kakao.com/o/sA8Kb83b",
+    "view" : 1,
+    "finishedRecruit" : false,
+    "recruitStart" : "2023-08-21",
+    "recruitEnd" : "2023-08-28",
+    "skills" : [ {
+      "skillId" : 1,
+      "name" : "Spring"
+    }, {
+      "skillId" : 2,
+      "name" : "React"
+    } ],
+    "limits" : [ {
+      "recruitType" : "백엔드",
+      "limit" : 3,
+      "currentNumber" : 1
+    }, {
+      "recruitType" : "프론트엔드",
+      "limit" : 3,
+      "currentNumber" : 0
+    } ],
+    "memberId" : 99,
+    "nickname" : "KIM",
+    "isMajor" : true,
+    "ssafyInfo" : {
+      "semester" : 9,
+      "campus" : "서울",
+      "certificationState" : "CERTIFIED",
+      "majorTrack" : "Java"
+    },
+    "scrapCount" : 1
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_상세_조회_response_fields"><a class="link" href="#_리크루트_상세_조회_response_fields">8.4.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집글 제목, 글자 수 제한 50자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 본문, 글자 수 제한 3000자, html 포함 4000자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contactURI</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 작성자와 연락 가능한 오픈톡 링크</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.view</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 상세 조회 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.finishedRecruit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 종료 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitStart</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd 모집 시작 일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitEnd</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd 모집 종료 일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.skills[].skillId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스킬 id (미사용)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.skills[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스킬명,  메타데이터-스킬 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.limits[].recruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집 타입, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.limits[].limit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집제한 인원</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.limits[].currentNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집인원</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피 정보 여부, null 또는 object</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 SSAFY 기수 1이상 10이하</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 소속 캠퍼스, 메타데이터-캠퍼스 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 SSAFY 인증 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 전공 트랙 Embedded | Mobile | Python | Java</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.scrapCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리쿠르트 스크랩 갯수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_업데이트"><a class="link" href="#_리크루트_업데이트">8.5. 리크루트 업데이트</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_업데이트_http_request"><a class="link" href="#_리크루트_업데이트_http_request">8.5.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /recruits/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 396
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "category" : "PROJECT",
+  "registerRecruitType" : "백엔드",
+  "recruitEnd" : "2025-12-01",
+  "title" : "제목 수정",
+  "content" : "&lt;p&gt;컨텐츠 수정입니다. &lt;/p&gt;",
+  "contactURI" : "github.com",
+  "skills" : [ "React", "Spring", "Svelte" ],
+  "limitations" : [ {
+    "recruitType" : "백엔드",
+    "limit" : 5
+  }, {
+    "recruitType" : "프론트엔드",
+    "limit" : 5
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_업데이트_cookie"><a class="link" href="#_리크루트_업데이트_cookie">8.5.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_업데이트_path_parameters"><a class="link" href="#_리크루트_업데이트_path_parameters">8.5.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_업데이트_request_fields"><a class="link" href="#_리크루트_업데이트_request_fields">8.5.4. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 카테고리 : PROJECT | STUDY</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>registerRecruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 리크루트 모집 타입, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitEnd</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd 모집 종료 일자, 당일 날짜 이후의 값으로만 설정 가능</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집글 제목, 글자 수 제한 50자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 본문, 글자 수 제한 3000자, html 포함 4000자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contactURI</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 작성자와 연락 가능한 오픈톡 링크</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>skills[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트와 연관된 기술 스택, 메타데이터-스킬 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>limitations[].recruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>limitations[].limit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인원 제한 1명이상 10명 이하</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_업데이트_http_response"><a class="link" href="#_리크루트_업데이트_http_response">8.5.5. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_업데이트_response_fields"><a class="link" href="#_리크루트_업데이트_response_fields">8.5.6. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_삭제"><a class="link" href="#_리크루트_삭제">8.6. 리크루트 삭제</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_삭제_http_request"><a class="link" href="#_리크루트_삭제_http_request">8.6.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /recruits/1 HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_삭제_cookie"><a class="link" href="#_리크루트_삭제_cookie">8.6.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_삭제_path_parameters"><a class="link" href="#_리크루트_삭제_path_parameters">8.6.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_삭제_http_response"><a class="link" href="#_리크루트_삭제_http_response">8.6.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_삭제_response_fields"><a class="link" href="#_리크루트_삭제_response_fields">8.6.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_목록_조회_2"><a class="link" href="#_리크루트_목록_조회_2">8.7. 리크루트 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_목록_조회_2_http_request"><a class="link" href="#_리크루트_목록_조회_2_http_request">8.7.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /recruits?size=20&amp;category=project&amp;keyword=%EC%82%AC%EC%9D%B4%EB%93%9C&amp;isFinished=false&amp;recruitTypes=%EB%B0%B1%EC%97%94%EB%93%9C&amp;recruitTypes=%ED%94%84%EB%A1%A0%ED%8A%B8%EC%97%94%EB%93%9C&amp;skills=Spring&amp;skills=React HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_목록_조회_2_request_parameters"><a class="link" href="#_리크루트_목록_조회_2_request_parameters">8.7.2. Request parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cursor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 조회 커서 default(초기화면)에서는 미포함</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이징 사이즈</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">카테고리 project|study</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>keyword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 게시글 제목 검색 키워드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isFinished</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 종료 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitTypes</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>skills</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트와 연관된 기술 스택, 메타데이터-스킬 목록 조회 참고</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_목록_조회_2_http_response"><a class="link" href="#_리크루트_목록_조회_2_http_response">8.7.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 838
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "recruits" : [ {
+      "recruitId" : 1,
+      "title" : "[사이드 프로젝트] 공모전 레퍼런스 웹 플랫폼 개발 프로젝트 팀원을 모집합니다.",
+      "finishedRecruit" : false,
+      "recruitEnd" : "2023-08-28",
+      "content" : "&lt;p&gt;[프로젝트 소개]&lt;/p&gt;\n저희 ",
+      "skills" : [ {
+        "skillId" : 1,
+        "name" : "Spring"
+      }, {
+        "skillId" : 2,
+        "name" : "React"
+      } ],
+      "participants" : [ {
+        "recruitType" : "백엔드",
+        "limit" : 4,
+        "members" : [ {
+          "nickname" : "KIM",
+          "major" : true
+        } ]
+      }, {
+        "recruitType" : "프론트엔드",
+        "limit" : 3,
+        "members" : [ ]
+      } ]
+    } ],
+    "nextCursor" : 1,
+    "isLast" : true
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_목록_조회_2_response_fields"><a class="link" href="#_리크루트_목록_조회_2_response_fields">8.7.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nextCursor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 조회할 커서 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isLast</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 페이지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집글 제목, 글자 수 제한 50자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 본문 요약본 최대 50자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].recruitEnd</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd 모집 종료 일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].finishedRecruit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 종료 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 멤버</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].skills[].skillId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스킬 id 미사용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].skills[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트와 연관된 기술 스택명, 메타데이터-스킬 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].recruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].limit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 모집 인원 제한 1명이상 10명 이하</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].major</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 전공 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_리크루트_참여_신청"><a class="link" href="#_리크루트_참여_신청">9. 리크루트 참여 신청</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_리크루트_참여_신청_2"><a class="link" href="#_리크루트_참여_신청_2">9.1. 리크루트 참여 신청</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_2_http_request"><a class="link" href="#_리크루트_참여_신청_2_http_request">9.1.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /recruits/1/application HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 117
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "recruitType" : "프론트엔드",
+  "contents" : [ "취업 준비를 위해서 신청하게되었습니다." ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_2_cookie"><a class="link" href="#_리크루트_참여_신청_2_cookie">9.1.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_2_path_parameters"><a class="link" href="#_리크루트_참여_신청_2_path_parameters">9.1.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}/application</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_2_request_fields"><a class="link" href="#_리크루트_참여_신청_2_request_fields">9.1.4. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 작성자가 선택한 자신의 역할군, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contents[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 등록자 질문에 대한 사용자 답변, [1개 필수]</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_2_http_response"><a class="link" href="#_리크루트_참여_신청_2_http_response">9.1.5. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_2_response_fields"><a class="link" href="#_리크루트_참여_신청_2_response_fields">9.1.6. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_등록자_참여_신청_수락"><a class="link" href="#_리크루트_등록자_참여_신청_수락">9.2. 리크루트 등록자 참여 신청 수락</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_등록자_참여_신청_수락_http_request"><a class="link" href="#_리크루트_등록자_참여_신청_수락_http_request">9.2.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /recruit-applications/1/approve HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_등록자_참여_신청_수락_cookie"><a class="link" href="#_리크루트_등록자_참여_신청_수락_cookie">9.2.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_등록자_참여_신청_수락_path_parameters"><a class="link" href="#_리크루트_등록자_참여_신청_수락_path_parameters">9.2.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-applications/{recruitApplicationId}/approve</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여신청 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_등록자_참여_신청_수락_http_response"><a class="link" href="#_리크루트_등록자_참여_신청_수락_http_response">9.2.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_등록자_참여_신청_수락_response_fields"><a class="link" href="#_리크루트_등록자_참여_신청_수락_response_fields">9.2.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_신청자_참여_확정"><a class="link" href="#_리크루트_신청자_참여_확정">9.3. 리크루트 신청자 참여 확정</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_확정_http_request"><a class="link" href="#_리크루트_신청자_참여_확정_http_request">9.3.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /recruit-applications/1/join HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_확정_cookie"><a class="link" href="#_리크루트_신청자_참여_확정_cookie">9.3.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_확정_path_parameters"><a class="link" href="#_리크루트_신청자_참여_확정_path_parameters">9.3.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-applications/{recruitApplicationId}/join</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여신청 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_확정_http_response"><a class="link" href="#_리크루트_신청자_참여_확정_http_response">9.3.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_확정_response_fields"><a class="link" href="#_리크루트_신청자_참여_확정_response_fields">9.3.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_참여_신청_거절"><a class="link" href="#_리크루트_참여_신청_거절">9.4. 리크루트 참여 신청 거절</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_거절_http_request"><a class="link" href="#_리크루트_참여_신청_거절_http_request">9.4.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /recruit-applications/1/reject HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_거절_cookie"><a class="link" href="#_리크루트_참여_신청_거절_cookie">9.4.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_거절_path_parameters"><a class="link" href="#_리크루트_참여_신청_거절_path_parameters">9.4.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-applications/{recruitApplicationId}/reject</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여신청 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_거절_http_response"><a class="link" href="#_리크루트_참여_신청_거절_http_response">9.4.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여_신청_거절_response_fields"><a class="link" href="#_리크루트_참여_신청_거절_response_fields">9.4.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_신청자_참여_신청_취소"><a class="link" href="#_리크루트_신청자_참여_신청_취소">9.5. 리크루트 신청자 참여 신청 취소</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_신청_취소_http_request"><a class="link" href="#_리크루트_신청자_참여_신청_취소_http_request">9.5.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /recruit-applications/1/cancel HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_신청_취소_cookie"><a class="link" href="#_리크루트_신청자_참여_신청_취소_cookie">9.5.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_신청_취소_path_parameters"><a class="link" href="#_리크루트_신청자_참여_신청_취소_path_parameters">9.5.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-applications/{recruitApplicationId}/cancel</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여신청 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_신청_취소_http_response"><a class="link" href="#_리크루트_신청자_참여_신청_취소_http_response">9.5.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_신청자_참여_신청_취소_response_fields"><a class="link" href="#_리크루트_신청자_참여_신청_취소_response_fields">9.5.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_참여자_목록_조회"><a class="link" href="#_리크루트_참여자_목록_조회">9.6. 리크루트 참여자 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_참여자_목록_조회_http_request"><a class="link" href="#_리크루트_참여자_목록_조회_http_request">9.6.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /recruits/1/members HTTP/1.1
+Host: api.ssafsound.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여자_목록_조회_path_parameters"><a class="link" href="#_리크루트_참여자_목록_조회_path_parameters">9.6.2. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}/members</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여자_목록_조회_http_response"><a class="link" href="#_리크루트_참여자_목록_조회_http_response">9.6.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 806
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "recruitTypes" : {
+      "백엔드" : {
+        "limit" : 4,
+        "members" : [ {
+          "memberId" : 99,
+          "nickname" : "KIM",
+          "isMajor" : true,
+          "ssafyInfo" : {
+            "semester" : 9,
+            "campus" : "서울",
+            "certificationState" : "CERTIFIED",
+            "majorTrack" : "Java"
+          }
+        } ]
+      },
+      "프론트엔드" : {
+        "limit" : 3,
+        "members" : [ {
+          "memberId" : 100,
+          "nickname" : "TIM",
+          "isMajor" : true,
+          "ssafyInfo" : {
+            "semester" : 9,
+            "campus" : "서울",
+            "certificationState" : "CERTIFIED",
+            "majorTrack" : "Java"
+          }
+        } ]
+      }
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_참여자_목록_조회_response_fields"><a class="link" href="#_리크루트_참여자_목록_조회_response_fields">9.6.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.limit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인원 제한 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.members[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.members[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.members[].isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.members[].ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 싸피 기수 (1~10)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.members[].ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 소속 캠퍼스 메타데이터-캠퍼스 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.members[].ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 ssafy 인증 여부 UNCERTIFIED | CERTIFIED</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitTypes.*.members[].ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공 트랙 Embedded | Mobile | Python | Java</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_등록자_리크루트_참여신청_목록_조회"><a class="link" href="#_등록자_리크루트_참여신청_목록_조회">9.7. 등록자 리크루트 참여신청 목록 조회"</a></h3>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_목록_조회_http_request"><a class="link" href="#_등록자_리크루트_참여신청_목록_조회_http_request">9.7.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /recruit-applications?recruitId=1 HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_목록_조회_cookie"><a class="link" href="#_등록자_리크루트_참여신청_목록_조회_cookie">9.7.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_목록_조회_request_parameters"><a class="link" href="#_등록자_리크루트_참여신청_목록_조회_request_parameters">9.7.3. Request parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_목록_조회_http_response"><a class="link" href="#_등록자_리크루트_참여신청_목록_조회_http_response">9.7.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 646
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "recruitApplications" : [ {
+      "recruitApplicationId" : 1,
+      "recruitType" : "프론트엔드",
+      "matchStatus" : "WAITING_REGISTER_APPROVE",
+      "memberId" : 100,
+      "nickname" : "TIM",
+      "isMajor" : true,
+      "ssafyInfo" : {
+        "semester" : 9,
+        "campus" : "서울",
+        "certificationState" : "CERTIFIED",
+        "majorTrack" : "Java"
+      },
+      "reply" : "취업 준비를 위해서 신청하게되었습니다.",
+      "question" : "프로젝트에 참여하고자 하는 동기가 무엇인가요?",
+      "isLike" : false
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_목록_조회_response_fields"><a class="link" href="#_등록자_리크루트_참여신청_목록_조회_response_fields">9.7.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].recruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청자가 선택한 자신의 역할군, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].matchStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (WAITING_APPLICANT:신청자 최종 수락 대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록자 질문</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].reply</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 답변</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].isLike</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록자 좋아요 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 싸피 기수 (1~10)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 소속 캠퍼스 메타데이터-캠퍼스 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 ssafy 인증 여부 UNCERTIFIED | CERTIFIED</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications[].ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공 트랙 Embedded | Mobile | Python | Java</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_등록자_리크루트_참여신청_좋아요"><a class="link" href="#_등록자_리크루트_참여신청_좋아요">9.8. 등록자 리크루트 참여신청 좋아요"</a></h3>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_좋아요_http_request"><a class="link" href="#_등록자_리크루트_참여신청_좋아요_http_request">9.8.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /recruit-applications/1/like HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_좋아요_cookie"><a class="link" href="#_등록자_리크루트_참여신청_좋아요_cookie">9.8.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_좋아요_path_parameters"><a class="link" href="#_등록자_리크루트_참여신청_좋아요_path_parameters">9.8.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-applications/{recruitApplicationId}/like</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_좋아요_http_response"><a class="link" href="#_등록자_리크루트_참여신청_좋아요_http_response">9.8.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_좋아요_response_fields"><a class="link" href="#_등록자_리크루트_참여신청_좋아요_response_fields">9.8.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_등록자_리크루트_참여신청_상세_조회"><a class="link" href="#_등록자_리크루트_참여신청_상세_조회">9.9. 등록자 리크루트 참여신청 상세 조회</a></h3>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_상세_조회_http_request"><a class="link" href="#_등록자_리크루트_참여신청_상세_조회_http_request">9.9.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /recruit-applications/1 HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_상세_조회_cookie"><a class="link" href="#_등록자_리크루트_참여신청_상세_조회_cookie">9.9.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_상세_조회_path_parameters"><a class="link" href="#_등록자_리크루트_참여신청_상세_조회_path_parameters">9.9.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-applications/{recruitApplicationId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_상세_조회_http_response"><a class="link" href="#_등록자_리크루트_참여신청_상세_조회_http_response">9.9.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 576
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "recruitApplicationId" : 1,
+    "recruitType" : "프론트엔드",
+    "matchStatus" : "WAITING_REGISTER_APPROVE",
+    "memberId" : 100,
+    "nickname" : "TIM",
+    "isMajor" : true,
+    "ssafyInfo" : {
+      "semester" : 9,
+      "campus" : "서울",
+      "certificationState" : "CERTIFIED",
+      "majorTrack" : "Java"
+    },
+    "reply" : "취업 준비를 위해서 신청하게되었습니다.",
+    "question" : "프로젝트에 참여하고자 하는 동기가 무엇인가요?",
+    "isLike" : false
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_등록자_리크루트_참여신청_상세_조회_response_fields"><a class="link" href="#_등록자_리크루트_참여신청_상세_조회_response_fields">9.9.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplicationId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청자가 선택한 자신의 역할군, 메타데이터-리크루트 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.matchStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (WAITING_APPLICANT:신청자 최종 수락 대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.question</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록자 질문</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.reply</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 답변</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isLike</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록자 좋아요 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.semester</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 싸피 기수 (1~10)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.campus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 소속 캠퍼스 메타데이터-캠퍼스 목록 조회 참고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.certificationState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 ssafy 인증 여부 UNCERTIFIED | CERTIFIED</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.ssafyInfo.majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공 트랙 Embedded | Mobile | Python | Java</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_리크루트_덧글"><a class="link" href="#_리크루트_덧글">10. 리크루트 덧글</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_리크루트_덧글_등록"><a class="link" href="#_리크루트_덧글_등록">10.1. 리크루트 덧글 등록</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_덧글_등록_http_request"><a class="link" href="#_리크루트_덧글_등록_http_request">10.1.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /recruits/1/comments HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 79
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "content" : "공모전 수상이 목표인가요?",
+  "commentGroup" : -1
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_등록_cookie"><a class="link" href="#_리크루트_덧글_등록_cookie">10.1.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_등록_path_parameters"><a class="link" href="#_리크루트_덧글_등록_path_parameters">10.1.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}/comments</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_등록_request_fields"><a class="link" href="#_리크루트_덧글_등록_request_fields">10.1.4. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">default: -1, 대댓글인 경우 해당 상위 덧글의 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_등록_http_response"><a class="link" href="#_리크루트_덧글_등록_http_response">10.1.5. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 219
+
+{
+  "code" : "200 OK",
+  "message" : "success",
+  "data" : {
+    "recruitCommentId" : 1,
+    "content" : "공모전 수상이 목표인가요?",
+    "memberId" : 100,
+    "nickname" : "TIM",
+    "commentGroup" : 1
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_등록_response_fields"><a class="link" href="#_리크루트_덧글_등록_response_fields">10.1.6. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.commentGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상위 덧글의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_덧글_삭제"><a class="link" href="#_리크루트_덧글_삭제">10.2. 리크루트 덧글 삭제</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_덧글_삭제_http_request"><a class="link" href="#_리크루트_덧글_삭제_http_request">10.2.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /recruit-comments/1 HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_삭제_cookie"><a class="link" href="#_리크루트_덧글_삭제_cookie">10.2.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_삭제_http_response"><a class="link" href="#_리크루트_덧글_삭제_http_response">10.2.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_삭제_response_fields"><a class="link" href="#_리크루트_덧글_삭제_response_fields">10.2.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_덧글_업데이트"><a class="link" href="#_리크루트_덧글_업데이트">10.3. 리크루트 덧글 업데이트</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_덧글_업데이트_http_request"><a class="link" href="#_리크루트_덧글_업데이트_http_request">10.3.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /recruit-comments/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 33
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue
+
+{
+  "content" : "덧글 수정"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_업데이트_cookie"><a class="link" href="#_리크루트_덧글_업데이트_cookie">10.3.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_업데이트_path_parameters"><a class="link" href="#_리크루트_덧글_업데이트_path_parameters">10.3.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-comments/{recruitCommentId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_업데이트_request_fields"><a class="link" href="#_리크루트_덧글_업데이트_request_fields">10.3.4. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_업데이트_http_response"><a class="link" href="#_리크루트_덧글_업데이트_http_response">10.3.5. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_업데이트_response_fields"><a class="link" href="#_리크루트_덧글_업데이트_response_fields">10.3.6. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_덧글_좋아요"><a class="link" href="#_리크루트_덧글_좋아요">10.4. 리크루트 덧글 좋아요</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_덧글_좋아요_http_request"><a class="link" href="#_리크루트_덧글_좋아요_http_request">10.4.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /recruit-comments/1/like HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_좋아요_cookie"><a class="link" href="#_리크루트_덧글_좋아요_cookie">10.4.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_좋아요_path_parameters"><a class="link" href="#_리크루트_덧글_좋아요_path_parameters">10.4.3. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruit-comments/{recruitCommentId}/like</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_좋아요_http_response"><a class="link" href="#_리크루트_덧글_좋아요_http_response">10.4.4. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 62
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_좋아요_response_fields"><a class="link" href="#_리크루트_덧글_좋아요_response_fields">10.4.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리크루트_덧글_목록_조회"><a class="link" href="#_리크루트_덧글_목록_조회">10.5. 리크루트 덧글 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_리크루트_덧글_목록_조회_http_request"><a class="link" href="#_리크루트_덧글_목록_조회_http_request">10.5.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /recruits/1/comments HTTP/1.1
+Host: api.ssafsound.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_목록_조회_path_parameters"><a class="link" href="#_리크루트_덧글_목록_조회_path_parameters">10.5.2. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /recruits/{recruitId}/comments</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 PK</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_목록_조회_http_response"><a class="link" href="#_리크루트_덧글_목록_조회_http_response">10.5.3. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 399
+
+{
+  "code" : "200",
+  "message" : "success",
+  "data" : {
+    "recruitComments" : [ {
+      "recruitCommentId" : 1,
+      "content" : "공모전 수상이 목표인가요?",
+      "commentGroup" : 1,
+      "children" : [ ],
+      "deletedComment" : false,
+      "memberId" : 100,
+      "nickname" : "TIM",
+      "ssafyMember" : true,
+      "isMajor" : true,
+      "majorTrack" : "Java"
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리크루트_덧글_목록_조회_response_fields"><a class="link" href="#_리크루트_덧글_목록_조회_response_fields">10.5.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].recruitCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 덧글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].commentGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 상위 덧글 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].deletedComment</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">덧글 삭제 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].children</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 [최대1개]</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 PK</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참여자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].ssafyMember</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">싸피생 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].isMajor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitComments[].majorTrack</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전공자 트랙</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_이미지_업로드"><a class="link" href="#_이미지_업로드">11. 이미지 업로드</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_이미지_업로드_url_요청"><a class="link" href="#_이미지_업로드_url_요청">11.1. 이미지 업로드 URL 요청</a></h3>
+<div class="sect3">
+<h4 id="_이미지_업로드_url_요청_http_request"><a class="link" href="#_이미지_업로드_url_요청_http_request">11.1.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /store/image HTTP/1.1
+Host: api.ssafsound.com
+Cookie: accessToken=accessTokenValue</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_이미지_업로드_url_요청_cookie"><a class="link" href="#_이미지_업로드_url_요청_cookie">11.1.2. Cookie</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Cookie</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_이미지_업로드_url_요청_http_response"><a class="link" href="#_이미지_업로드_url_요청_http_response">11.1.3. HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1821,7 +7380,7 @@ Content-Length: 663
 </div>
 </div>
 <div class="sect3">
-<h4 id="_이미지_업로드_url_요청_response_fields"><a class="link" href="#_이미지_업로드_url_요청_response_fields">7.1.4. Response fields</a></h4>
+<h4 id="_이미지_업로드_url_요청_response_fields"><a class="link" href="#_이미지_업로드_url_요청_response_fields">11.1.4. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1876,7 +7435,7 @@ Content-Length: 663
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-15 15:51:06 +0900
+Last updated 2023-08-19 14:27:27 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
@@ -444,4 +444,23 @@ class MemberControllerTest extends ControllerTest {
                         getEnvelopPatternWithNoContent()))
                 .expect(status().isOk());
     }
+
+    @DisplayName("전공자 여부에 대한 변경에 성공한다.")
+    @Test
+    void changeMemberMajor() {
+
+        restDocs
+                .cookie(ACCESS_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(MemberFixture.PATCH_IS_MAJOR_REQUEST)
+                .when().patch("members/major")
+                .then().log().all()
+                .assertThat()
+                .apply(document("members/change-isMajor",
+                        requestCookieAccessTokenMandatory(),
+                        requestFields(
+                                fieldWithPath("isMajor").description("전공자유무")),
+                        getEnvelopPatternWithNoContent()))
+                .expect(status().isOk());
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
@@ -463,4 +463,24 @@ class MemberControllerTest extends ControllerTest {
                         getEnvelopPatternWithNoContent()))
                 .expect(status().isOk());
     }
+
+    @DisplayName("전공트랙에 대한 변경에 성공한다.")
+    @Test
+    void changeMemberMajorTrack() {
+
+        restDocs
+                .cookie(ACCESS_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(MemberFixture.PATCH_MEMBER_MAJOR_TRACK)
+                .when().patch("members/major-track")
+                .then().log().all()
+                .assertThat()
+                .apply(document("members/change-majorTrack",
+                        requestCookieAccessTokenMandatory(),
+                        requestFields(
+                                fieldWithPath("majorTrack")
+                                        .description("전공트랙(\"Embedded\" , \"Python\" , \"Java\" , \"Mobile\")")),
+                        getEnvelopPatternWithNoContent()))
+                .expect(status().isOk());
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -522,4 +522,20 @@ class MemberServiceTest {
         //verify
         verify(memberRepository, times(1)).findById(member.getId());
     }
+
+    @Test
+    @DisplayName("멤버는 전공자 여부를 수정하는데 성공한다.")
+    void Given_Member_WhenChangeMajor_Then_Success() {
+        //given
+        PatchMemberMajorReqDto patchMemberMajorReqDto = PatchMemberMajorReqDto
+                .builder()
+                .isMajor(false)
+                .build();
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+
+        memberService.changeMemberMajor(member.getId(), patchMemberMajorReqDto);
+
+        //verify
+        verify(memberRepository, times(1)).findById(member.getId());
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
@@ -75,6 +75,10 @@ public class MemberFixture {
             .publicProfile(true)
             .build();
 
+    public static final PatchMemberMajorReqDto PATCH_IS_MAJOR_REQUEST = PatchMemberMajorReqDto.builder()
+            .isMajor(false)
+            .build();
+
     public static Set<MemberLink> memberLinks = new HashSet<>(){
         {
             add(MemberLink.builder().member(MEMBER_JAMES).linkName("velog").path("http://test-link1").build());

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
@@ -212,4 +212,8 @@ public class MemberFixture {
             .ssafyMember(true)
             .major(true)
             .build();
+
+    public static final PatchMemberMajorTrackReqDto PATCH_MEMBER_MAJOR_TRACK = PatchMemberMajorTrackReqDto.builder()
+            .majorTrack("Embedded")
+            .build();
 }


### PR DESCRIPTION
## Issues

- #157 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 큰 구현 사항은 없습니다. 전공자 유무에 대해서는 싸피생과 상관없이 변경할 수 있어야 하기 때문에 멤버 정보 인증 및 Client의 전공자 유무 Boolean값을 받고 있습니다.
- 전공자 트랙에 대해서 변경할 수 있으나 싸피생만 변경할 수 있습니다. 따라서 싸피생 유무 검증, 전공트랙에 대한 Validation은 MetaDataConsumer가 처리합니다.
- 서비스 및 컨트롤러 테스트를 추가했습니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
