### PR TITLE
refactor: recruit application matchstatus

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/SsafsoundApplication.java
+++ b/src/main/java/com/ssafy/ssafsound/SsafsoundApplication.java
@@ -1,6 +1,5 @@
 package com.ssafy.ssafsound;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
@@ -15,7 +15,8 @@ public enum RecruitErrorInfo {
     IS_DELETED("908", "이미 삭제된 스터디/프로젝트입니다."),
     NOT_BELOW_PREV_LIMITATIONS("909", "스터디/프로젝트 인원은 감소할 수 없습니다."),
     NOT_FOUND_RECRUIT("910", "모집글을 찾을 수 없습니다."),
-    NOT_FOUND_RECRUIT_COMMENT("911", "모집글 QNA를 찾을 수 없습니다.");
+    NOT_FOUND_RECRUIT_COMMENT("911", "모집글 QNA를 찾을 수 없습니다."),
+    PREV_EXIST_MEMBER_APPLICATION("912", "이미 신청한 스터디/프로젝트 입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -42,7 +42,7 @@ public class RecruitApplicationController {
     @PatchMapping("/recruit-applications/{recruitApplicationId}/cancel")
     public EnvelopeResponse<PatchRecruitApplicationStatusResDto> cancelRecruitApplicationByParticipant(@PathVariable Long recruitApplicationId, @Authentication AuthenticatedMember memberInfo) {
         return EnvelopeResponse.<PatchRecruitApplicationStatusResDto>builder()
-            .data(recruitApplicationService.cancelRecruitApplicationByParticipant(recruitApplicationId, memberInfo.getMemberId(), MatchStatus.CANCEL))
+            .data(recruitApplicationService.cancelRecruitApplication(recruitApplicationId, memberInfo.getMemberId(), MatchStatus.CANCEL))
             .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -28,14 +28,7 @@ public class RecruitApplicationController {
     @PatchMapping("/recruit-applications/{recruitApplicationId}/approve")
     public EnvelopeResponse<PatchRecruitApplicationStatusResDto> approveRecruitApplicationByRegister(@PathVariable Long recruitApplicationId, @Authentication AuthenticatedMember memberInfo) {
         return EnvelopeResponse.<PatchRecruitApplicationStatusResDto>builder()
-            .data(recruitApplicationService.approveRecruitApplicationByRegister(recruitApplicationId, memberInfo.getMemberId(), MatchStatus.WAITING_APPLICANT))
-            .build();
-    }
-
-    @PatchMapping("/recruit-applications/{recruitApplicationId}/join")
-    public EnvelopeResponse<PatchRecruitApplicationStatusResDto> joinRecruitApplication(@PathVariable Long recruitApplicationId, @Authentication AuthenticatedMember memberInfo) {
-        return EnvelopeResponse.<PatchRecruitApplicationStatusResDto>builder()
-            .data(recruitApplicationService.joinRecruitApplication(recruitApplicationId, memberInfo.getMemberId(), MatchStatus.DONE))
+            .data(recruitApplicationService.approveRecruitApplicationByRegister(recruitApplicationId, memberInfo.getMemberId(), MatchStatus.DONE))
             .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/domain/MatchStatus.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/domain/MatchStatus.java
@@ -1,5 +1,5 @@
 package com.ssafy.ssafsound.domain.recruitapplication.domain;
 
 public enum MatchStatus {
-    WAITING_REGISTER_APPROVE, WAITING_APPLICANT, DONE, REJECT, CANCEL
+    WAITING_REGISTER_APPROVE, DONE, REJECT, CANCEL
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -44,4 +44,6 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
     List<RecruitApplication> findByRecruitIdAndMatchStatus(Long recruitId, MatchStatus matchStatus);
 
     void deleteByTypeNotIn(List<MetaData> recruitTypes);
+
+    RecruitApplication findTopByRecruitIdAndMemberIdOrderByIdDescLimit(Long recruitId, Long memberId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -17,7 +17,7 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
     Optional<RecruitApplication> findByIdFetchRecruitWriter(Long recruitApplicationId);
 
     @Query("SELECT r FROM recruit_application r left join r.member left join fetch r.recruit left join r.recruit.member where r.id = :recruitApplicationId")
-    Optional<RecruitApplication> findByIdAndMemberIdFetchRecruitWriter(Long recruitApplicationId);
+    Optional<RecruitApplication> findByIdFetchParticipantAndRecruitWriter(Long recruitApplicationId);
 
     Optional<RecruitApplication> findByIdAndMemberId(Long recruitApplicationId, Long memberId);
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -45,5 +45,5 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
 
     void deleteByTypeNotIn(List<MetaData> recruitTypes);
 
-    RecruitApplication findTopByRecruitIdAndMemberIdOrderByIdDescLimit(Long recruitId, Long memberId);
+    RecruitApplication findTopByRecruitIdAndMemberIdOrderByIdDesc(Long recruitId, Long memberId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -75,17 +75,6 @@ public class RecruitApplicationService {
     }
 
     @Transactional
-    public PatchRecruitApplicationStatusResDto joinRecruitApplication(Long recruitApplicationId, Long memberId, MatchStatus status) {
-        RecruitApplication recruitApplication = recruitApplicationRepository.findByIdAndMemberId(recruitApplicationId, memberId)
-                .orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
-
-        RecruitLimitation recruitLimitation = getNotFullRecruitLimitation(recruitApplication.getRecruit(), recruitApplication.getType());
-        recruitLimitation.increaseCurrentNumber();
-        return changeRecruitApplicationState(recruitApplication, memberId, status,
-                (entity, mid)-> !entity.getMatchStatus().equals(MatchStatus.WAITING_APPLICANT));
-    }
-
-    @Transactional
     public PatchRecruitApplicationStatusResDto rejectRecruitApplication(Long recruitApplicationId, Long memberId, MatchStatus status) {
         RecruitApplication recruitApplication = recruitApplicationRepository.findByIdAndMemberIdFetchRecruitWriter(recruitApplicationId)
                 .orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
@@ -93,8 +82,7 @@ public class RecruitApplicationService {
         return changeRecruitApplicationState(recruitApplication, memberId, status,
                 (entity, mid)-> {
                     boolean isNotValidRegisterAndState = (!entity.getRecruit().getMember().getId().equals(mid) || !entity.getMatchStatus().equals(MatchStatus.WAITING_REGISTER_APPROVE));
-                    boolean isNotValidParticipantAndStatus = (!entity.getMember().getId().equals(mid) || !entity.getMatchStatus().equals(MatchStatus.WAITING_APPLICANT));
-                    return isNotValidRegisterAndState && isNotValidParticipantAndStatus;
+                    return isNotValidRegisterAndState;
                 });
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -135,7 +135,7 @@ public class RecruitApplicationService {
     }
 
     private boolean isPrevExistWaitingOrDoneMember(Long recruitId, Long memberId) {
-        RecruitApplication recentRecruitApplication = recruitApplicationRepository.findTopByRecruitIdAndMemberIdOrderByIdDescLimit(recruitId, memberId);
+        RecruitApplication recentRecruitApplication = recruitApplicationRepository.findTopByRecruitIdAndMemberIdOrderByIdDesc(recruitId, memberId);
         if(recentRecruitApplication == null) return false;
 
         boolean prevWaitingMember = recentRecruitApplication.getMatchStatus().equals(MatchStatus.WAITING_REGISTER_APPROVE);

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -831,7 +831,7 @@ Content-Length: 954
       "content" : "저도 싸피에서 교육들으면 개발실력 엄청 오르겠죠?",
       "likeCount" : 11,
       "commentCount" : 29,
-      "createdAt" : "2023-08-28T19:52:14.655798",
+      "createdAt" : "2023-09-02T21:28:43.243248",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -843,7 +843,7 @@ Content-Length: 954
       "content" : "역시 B형 특강을 열심히 듣는게 맞나요?",
       "likeCount" : 5,
       "commentCount" : 14,
-      "createdAt" : "2023-08-28T19:52:14.655814",
+      "createdAt" : "2023-09-02T21:28:43.243277",
       "nickname" : "익명",
       "anonymity" : true,
       "thumbnail" : "썸네일 URL"
@@ -1599,7 +1599,7 @@ Content-Length: 490
       "content" : "SSAFY 9기 합격했습니다!!",
       "likeCount" : 3,
       "commentCount" : 2,
-      "createdAt" : "2023-08-28T19:52:14.65582",
+      "createdAt" : "2023-09-02T21:28:43.243283",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2508,7 +2508,7 @@ Content-Length: 908
       "content" : "열심히 SSAFY 9기를 수료하시면 취업에 성공하실겁니다.",
       "likeCount" : 102,
       "commentCount" : 33,
-      "createdAt" : "2023-08-28T19:52:14.655825",
+      "createdAt" : "2023-09-02T21:28:43.243288",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2520,7 +2520,7 @@ Content-Length: 908
       "content" : "은 실력입니다.",
       "likeCount" : 202,
       "commentCount" : 54,
-      "createdAt" : "2023-08-28T19:52:14.65583",
+      "createdAt" : "2023-09-02T21:28:43.243294",
       "nickname" : "익명",
       "anonymity" : true,
       "thumbnail" : "썸네일 URL"
@@ -2712,7 +2712,7 @@ Content-Length: 533
       "content" : "열심히 SSAFY 9기를 수료하시면 취업에 성공하실겁니다.",
       "likeCount" : 102,
       "commentCount" : 33,
-      "createdAt" : "2023-08-28T19:52:14.655825",
+      "createdAt" : "2023-09-02T21:28:43.243288",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2908,7 +2908,7 @@ Content-Length: 923
       "content" : "SSAFY 9기 합격했습니다!!",
       "likeCount" : 3,
       "commentCount" : 2,
-      "createdAt" : "2023-08-28T19:52:14.655833",
+      "createdAt" : "2023-09-02T21:28:43.243296",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2920,7 +2920,7 @@ Content-Length: 923
       "content" : "열심히 SSAFY 9기를 수료하시면 취업에 성공하실겁니다.",
       "likeCount" : 102,
       "commentCount" : 33,
-      "createdAt" : "2023-08-28T19:52:14.655835",
+      "createdAt" : "2023-09-02T21:28:43.243299",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -3112,7 +3112,7 @@ Content-Length: 954
       "content" : "역시 B형 특강을 열심히 듣는게 맞나요?",
       "likeCount" : 5,
       "commentCount" : 14,
-      "createdAt" : "2023-08-28T19:52:14.655814",
+      "createdAt" : "2023-09-02T21:28:43.243277",
       "nickname" : "익명",
       "anonymity" : true,
       "thumbnail" : "썸네일 URL"
@@ -3124,7 +3124,7 @@ Content-Length: 954
       "content" : "저도 싸피에서 교육들으면 개발실력 엄청 오르겠죠?",
       "likeCount" : 11,
       "commentCount" : 29,
-      "createdAt" : "2023-08-28T19:52:14.655798",
+      "createdAt" : "2023-09-02T21:28:43.243248",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -3317,7 +3317,7 @@ Content-Length: 1233
       "commentId" : 1,
       "content" : "반가워요",
       "likeCount" : 3,
-      "createdAt" : "2023-08-28T19:52:14.653747",
+      "createdAt" : "2023-09-02T21:28:41.716375",
       "anonymity" : true,
       "modified" : false,
       "liked" : true,
@@ -3335,7 +3335,7 @@ Content-Length: 1233
         "commentId" : 1,
         "content" : "안녕하세요",
         "likeCount" : 10,
-        "createdAt" : "2023-08-28T19:52:14.653256",
+        "createdAt" : "2023-09-02T21:28:41.715807",
         "anonymity" : false,
         "modified" : false,
         "liked" : false,
@@ -4788,8 +4788,8 @@ Host: api.ssafsound.com
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Domain=ssafsound.com; Max-Age=2629744; Expires=Wed, 27 Sep 2023 21:21:18 GMT; Secure; HttpOnly
-Set-Cookie: refreshToken=syJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IsdfserwetweSflKxwRJeSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Domain=ssafsound.com; Max-Age=2629744; Expires=Wed, 27 Sep 2023 21:21:18 GMT; Secure; HttpOnly
+Set-Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Domain=ssafsound.com; Max-Age=2629744; Expires=Mon, 02 Oct 2023 22:57:45 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=syJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IsdfserwetweSflKxwRJeSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Domain=ssafsound.com; Max-Age=2629744; Expires=Mon, 02 Oct 2023 22:57:45 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 415
 
@@ -7937,7 +7937,7 @@ Cookie: accessToken=accessTokenValue
 
 {
   "category" : "PROJECT",
-  "recruitEnd" : "2023-09-04",
+  "recruitEnd" : "2023-09-09",
   "title" : "[사이드 프로젝트] 공모전 레퍼런스 웹 플랫폼 개발 프로젝트 팀원을 모집합니다.",
   "content" : "&lt;p&gt;[프로젝트 소개]&lt;/p&gt;\n저희 프로젝트는 대학생들의 공모전 경험에 있어 누구나 참고할 레퍼런스를 제공받고, 또 자발적으로 공유할 수 있는 환경을 구축하고자 시작하게 되었습니다! 저희 프로젝트는 아래와 같은 특징을 가지고 있습니다.\n현재 PM 1명, 프론트엔드 개발자 2명, 백엔드 개발자 1명이 있으며, 디자인의 경우 PM이 1차 MVP의 UI/UX를 제작했습니다.\n",
   "contactURI" : "https://open.kakao.com/o/sA8Kb83b",
@@ -8409,8 +8409,8 @@ Content-Length: 1676
     "contactURI" : "https://open.kakao.com/o/sA8Kb83b",
     "view" : 1,
     "finishedRecruit" : false,
-    "recruitStart" : "2023-08-28",
-    "recruitEnd" : "2023-09-04",
+    "recruitStart" : "2023-09-02",
+    "recruitEnd" : "2023-09-09",
     "skills" : [ {
       "skillId" : 1,
       "name" : "Spring"
@@ -8996,7 +8996,7 @@ Content-Length: 838
       "recruitId" : 1,
       "title" : "[사이드 프로젝트] 공모전 레퍼런스 웹 플랫폼 개발 프로젝트 팀원을 모집합니다.",
       "finishedRecruit" : false,
-      "recruitEnd" : "2023-09-04",
+      "recruitEnd" : "2023-09-09",
       "content" : "&lt;p&gt;[프로젝트 소개]&lt;/p&gt;\n저희 ",
       "skills" : [ {
         "skillId" : 1,
@@ -9288,7 +9288,7 @@ Content-Length: 142
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.matchStatus</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
 </tr>
 </tbody>
 </table>
@@ -9358,14 +9358,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 135
+Content-Length: 122
 
 {
   "code" : "200",
   "message" : "success",
   "data" : {
     "recruitApplicationId" : 1,
-    "matchStatus" : "WAITING_APPLICANT"
+    "matchStatus" : "DONE"
   }
 }</code></pre>
 </div>
@@ -9410,7 +9410,7 @@ Content-Length: 135
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.matchStatus</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
 </tr>
 </tbody>
 </table>
@@ -9420,56 +9420,21 @@ Content-Length: 135
 <h3 id="_리크루트_신청자_참여_확정"><a class="link" href="#_리크루트_신청자_참여_확정">11.3. 리크루트 신청자 참여 확정</a></h3>
 <div class="sect3">
 <h4 id="_리크루트_신청자_참여_확정_http_request"><a class="link" href="#_리크루트_신청자_참여_확정_http_request">11.3.1. HTTP request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /recruit-applications/1/join HTTP/1.1
-Host: api.ssafsound.com
-Cookie: accessToken=accessTokenValue</code></pre>
-</div>
+<div class="paragraph">
+<p>Snippet http-request not found for operation::recruitApplication/application-join</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_리크루트_신청자_참여_확정_cookie"><a class="link" href="#_리크루트_신청자_참여_확정_cookie">11.3.2. Cookie</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Cookie</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰 필수</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Snippet cookie not found for operation::recruitApplication/application-join</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_리크루트_신청자_참여_확정_path_parameters"><a class="link" href="#_리크루트_신청자_참여_확정_path_parameters">11.3.3. Path parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /recruit-applications/{recruitApplicationId}/join</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recruitApplicationId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여신청 PK</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Snippet path-parameters not found for operation::recruitApplication/application-join</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_리크루트_신청자_참여_확정_http_response"><a class="link" href="#_리크루트_신청자_참여_확정_http_response">11.3.4. HTTP response</a></h4>
@@ -9495,47 +9460,9 @@ Content-Length: 122
 </div>
 <div class="sect3">
 <h4 id="_리크루트_신청자_참여_확정_response_fields"><a class="link" href="#_리크루트_신청자_참여_확정_response_fields">11.3.5. Response fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplicationId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 PK</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.matchStatus</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Snippet response-fields not found for operation::recruitApplication/application-join</p>
+</div>
 </div>
 </div>
 <div class="sect2">
@@ -9654,7 +9581,7 @@ Content-Length: 124
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.matchStatus</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
 </tr>
 </tbody>
 </table>
@@ -9776,7 +9703,7 @@ Content-Length: 124
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.matchStatus</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)</p></td>
 </tr>
 </tbody>
 </table>
@@ -10087,7 +10014,7 @@ Content-Length: 831
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications.*.[].matchStatus</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (WAITING_APPLICANT:신청자 최종 수락 대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruitApplications.*.[].author.memberId</code></p></td>
@@ -10413,7 +10340,7 @@ Content-Length: 694
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.matchStatus</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (WAITING_APPLICANT:신청자 최종 수락 대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.author.memberId</code></p></td>
@@ -11086,7 +11013,7 @@ Content-Length: 741
       "likeCount" : 0,
       "liked" : false,
       "mine" : false,
-      "createdAt" : "2023-08-28T19:52:16.81976",
+      "createdAt" : "2023-09-02T21:28:43.95473",
       "deletedComment" : false,
       "modified" : false,
       "author" : {

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
@@ -105,7 +105,7 @@ public class RecruitApplicationControllerTest extends ControllerTest {
     void cancelRecruitApplicationByParticipant() {
         doReturn(RecruitApplicationFixture.CANCEL_STATUS_APPLICATION)
             .when(recruitApplicationService)
-            .cancelRecruitApplicationByParticipant(any(), any(), any());
+            .cancelRecruitApplication(any(), any(), any());
 
         restDocs
                 .cookie(ACCESS_TOKEN)

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
@@ -45,7 +45,7 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                         ),
                         getEnvelopPatternWithData().andWithPrefix("data.",
                             fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
-                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
+                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
                         ))
                 );
     }
@@ -70,7 +70,7 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                         ),
                         getEnvelopPatternWithData().andWithPrefix("data.",
                             fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
-                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
+                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
                         ))
                 );
     }
@@ -95,14 +95,14 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                         ),
                         getEnvelopPatternWithData().andWithPrefix("data.",
                             fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
-                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
+                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
                         ))
                 );
     }
 
-    @DisplayName("리크루트 신청자 참여 신청 취소")
+    @DisplayName("리크루트 등록자 / 신청자 참여 신청 취소")
     @Test
-    void cancelRecruitApplicationByParticipant() {
+    void cancelRecruitApplication() {
         doReturn(RecruitApplicationFixture.CANCEL_STATUS_APPLICATION)
             .when(recruitApplicationService)
             .cancelRecruitApplication(any(), any(), any());
@@ -120,7 +120,7 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                         ),
                         getEnvelopPatternWithData().andWithPrefix("data.",
                             fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
-                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
+                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
                         ))
                 );
     }
@@ -182,7 +182,7 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                                 fieldWithPath("category").type(JsonFieldType.STRING).description("PROJECT | STUDY")
                         ).andWithPrefix("data.recruitApplications.*.[].",
                                 fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
-                                fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (WAITING_APPLICANT:신청자 최종 수락 대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)"),
+                                fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)"),
                                 fieldWithPath("author.memberId").type(JsonFieldType.NUMBER).description("참여자 PK"),
                                 fieldWithPath("author.nickname").type(JsonFieldType.STRING).description("참여자 닉네임"),
                                 fieldWithPath("author.isMajor").type(JsonFieldType.BOOLEAN).description("전공자 여부"),
@@ -247,7 +247,7 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                                 fieldWithPath("recruitId").type(JsonFieldType.NUMBER).description("리크루트 PK"),
                                 fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
                                 fieldWithPath("recruitType").type(JsonFieldType.STRING).description("리크루트 참여 신청자가 선택한 자신의 역할군, 메타데이터-리크루트 목록 조회 참고"),
-                                fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (WAITING_APPLICANT:신청자 최종 수락 대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)"),
+                                fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("매칭 상태 - (WAITING_REGISTER_APPROVE:등록자 수락대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)"),
                                 fieldWithPath("author.memberId").type(JsonFieldType.NUMBER).description("참여자 PK"),
                                 fieldWithPath("author.nickname").type(JsonFieldType.STRING).description("참여자 닉네임"),
                                 fieldWithPath("author.memberRole").type(JsonFieldType.STRING).description("참여자 권한"),

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
@@ -53,7 +53,7 @@ public class RecruitApplicationControllerTest extends ControllerTest {
     @DisplayName("리크루트 등록자 참여 신청 수락")
     @Test
     void approveRecruitApplicationByRegister() {
-        doReturn(RecruitApplicationFixture.APPROVE_STATUS_APPLICATION)
+        doReturn(RecruitApplicationFixture.DONE_STATUS_APPLICATION)
             .when(recruitApplicationService)
             .approveRecruitApplicationByRegister(any(), any(), any());
 
@@ -64,31 +64,6 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                 .assertThat()
                 .statusCode(HttpStatus.OK.value())
                 .apply(document("recruitApplication/application-approve",
-                        requestCookieAccessTokenMandatory(),
-                        pathParameters(
-                                parameterWithName("recruitApplicationId").description("리크루트 참여신청 PK")
-                        ),
-                        getEnvelopPatternWithData().andWithPrefix("data.",
-                            fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
-                            fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("리크루트 참여 신청 매칭 상태 WAITING_REGISTER_APPROVE (등록자 수락 대기상태) | WAITING_APPLICANT (신청자 수락 대기상태) | DONE (매칭성공) | REJECT (매칭거절) | CANCEL (매칭 취소)")
-                        ))
-                );
-    }
-
-    @DisplayName("리크루트 신청자 참여 확정")
-    @Test
-    void joinRecruitApplication() {
-        doReturn(RecruitApplicationFixture.DONE_STATUS_APPLICATION)
-            .when(recruitApplicationService)
-            .joinRecruitApplication(any(), any(), any());
-
-        restDocs
-                .cookie(ACCESS_TOKEN)
-                .when().patch("/recruit-applications/{recruitApplicationId}/join", 1)
-                .then().log().all()
-                .assertThat()
-                .statusCode(HttpStatus.OK.value())
-                .apply(document("recruitApplication/application-join",
                         requestCookieAccessTokenMandatory(),
                         pathParameters(
                                 parameterWithName("recruitApplicationId").description("리크루트 참여신청 PK")

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -136,7 +136,7 @@ class RecruitApplicationServiceTest {
                 .thenReturn(java.util.Optional.ofNullable(recruitApplication));
         lenient().when(recruitApplicationRepository.findByIdFetchRecruitWriter(1L))
                 .thenReturn(java.util.Optional.ofNullable(recruitApplication));
-        lenient().when(recruitApplicationRepository.findByIdAndMemberIdFetchRecruitWriter(1L))
+        lenient().when(recruitApplicationRepository.findByIdFetchParticipantAndRecruitWriter(1L))
                 .thenReturn(java.util.Optional.ofNullable(recruitApplication));
         lenient().when(recruitApplicationRepository.findByRecruitIdAndMatchStatusFetchMember(1L, MatchStatus.DONE))
                 .thenReturn(recruitApplications);
@@ -215,7 +215,7 @@ class RecruitApplicationServiceTest {
     @DisplayName("등록자 승인 전, 사용자 리크루트 참여 신청 취소")
     @Test
     void Given_NormalRequest_When_CancelRecruitApplication_Then_Success() {
-        assertDoesNotThrow(()-> recruitApplicationService.cancelRecruitApplicationByParticipant(1L, 2L, MatchStatus.CANCEL));
+        assertDoesNotThrow(()-> recruitApplicationService.cancelRecruitApplication(1L, 2L, MatchStatus.CANCEL));
     }
 
     @DisplayName("등록자 사용자 리크루트 신청 승인")

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -218,17 +218,10 @@ class RecruitApplicationServiceTest {
         assertDoesNotThrow(()-> recruitApplicationService.cancelRecruitApplicationByParticipant(1L, 2L, MatchStatus.CANCEL));
     }
 
-    @DisplayName("등록자 승인 이후 사용자 리크루트 참여 신청 취소 실패")
-    @Test
-    void Given_AfterApproveByRegisterRecruitApplication_When_CancelRecruitApplication_Then_Fail() {
-        recruitApplication.changeStatus(MatchStatus.WAITING_APPLICANT);
-        assertThrows(RecruitException.class, ()->recruitApplicationService.cancelRecruitApplicationByParticipant(1L, 2L, MatchStatus.CANCEL));
-    }
-
-    @DisplayName("등록자 승인 사용자 리크루트 신청 승인")
+    @DisplayName("등록자 사용자 리크루트 신청 승인")
     @Test
     void Given_NormalRequest_When_ApproveRecruitApplicationByRegister_Then_Success() {
-        assertDoesNotThrow(()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 1L, MatchStatus.WAITING_APPLICANT));
+        assertDoesNotThrow(()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 1L, MatchStatus.DONE));
     }
 
     @DisplayName("이미 모두 모집된 리크루트글에 대한 등록자 승인 사용자 리크루트 신청 승인")
@@ -241,37 +234,20 @@ class RecruitApplicationServiceTest {
                 .type(new MetaData(RecruitType.DESIGN))
                 .build());
         recruit.setRecruitLimitations(limits);
-        assertThrows(RecruitException.class, ()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 1L, MatchStatus.WAITING_APPLICANT));
+        assertThrows(RecruitException.class, ()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 1L, MatchStatus.DONE));
     }
 
     @DisplayName("등록자가 아닌 사용자의 사용자 리크루트 신청 승인 실패")
     @Test
     void Given_NotRegister_When_ApproveRecruitApplicationByRegister_Then_Fail() {
-        assertThrows(RecruitException.class, ()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 2L, MatchStatus.WAITING_APPLICANT));
+        assertThrows(RecruitException.class, ()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 2L, MatchStatus.DONE));
     }
 
     @DisplayName("취소된 신청에 대한 등록자 승인 실패")
     @Test
     void Given_CancelRecruitApplication_When_ApproveRecruitApplicationByRegister_Then_Fail() {
         recruitApplication.changeStatus(MatchStatus.CANCEL);
-        assertThrows(RecruitException.class, ()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 1L, MatchStatus.WAITING_APPLICANT));
-    }
-
-    @DisplayName("사용자 리크루트 신청 최종 참여 승인")
-    @Test
-    void Given_NormalRequest_When_JoinRecruitApplicationByParticipant_Then_Success() {
-        recruitApplication.changeStatus(MatchStatus.WAITING_APPLICANT);
-        recruitApplicationService.joinRecruitApplication(1L, 2L, MatchStatus.DONE);
-        assertEquals(1, limits.get(0).getCurrentNumber());
-    }
-
-    @DisplayName("사용자 리크루트 신청 최종 참여 거절")
-    @Test
-    void Given_NormalRequest_When_RejectRecruitApplicationByParticipant_Then_Success() {
-        recruitApplication.changeStatus(MatchStatus.WAITING_APPLICANT);
-        assertDoesNotThrow(
-                ()->recruitApplicationService.rejectRecruitApplication(1L, 2L, MatchStatus.REJECT)
-        );
+        assertThrows(RecruitException.class, ()-> recruitApplicationService.approveRecruitApplicationByRegister(1L, 1L, MatchStatus.DONE));
     }
 
     @DisplayName("사용자 리크루트 신청 최종 참여 거절 실패")
@@ -293,7 +269,7 @@ class RecruitApplicationServiceTest {
     @DisplayName("등록자 리크루트 신청 거절 실패")
     @Test
     void Given_NotValidStatus_When_RejectRecruitApplicationByRegister_Then_Success() {
-        recruitApplication.changeStatus(MatchStatus.WAITING_APPLICANT);
+        recruitApplication.changeStatus(MatchStatus.DONE);
         assertThrows(RecruitException.class,
                 ()->recruitApplicationService.rejectRecruitApplication(1L, 1L, MatchStatus.REJECT)
         );

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitApplicationFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitApplicationFixture.java
@@ -48,8 +48,6 @@ public class RecruitApplicationFixture {
 
     public static final PatchRecruitApplicationStatusResDto WAITING_STATUS_APPLICATION = new PatchRecruitApplicationStatusResDto(1L, MatchStatus.WAITING_REGISTER_APPROVE.name());
 
-    public static final PatchRecruitApplicationStatusResDto APPROVE_STATUS_APPLICATION = new PatchRecruitApplicationStatusResDto(1L, MatchStatus.WAITING_APPLICANT.name());
-
     public static final PatchRecruitApplicationStatusResDto REJECT_STATUS_APPLICATION = new PatchRecruitApplicationStatusResDto(1L, MatchStatus.REJECT.name());
 
     public static final PatchRecruitApplicationStatusResDto CANCEL_STATUS_APPLICATION = new PatchRecruitApplicationStatusResDto(1L, MatchStatus.CANCEL.name());


### PR DESCRIPTION
## Issues

- #238

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

### 리크루트 상태 로직 수정 
```
기존
WAITING_REGISTER_APPROVE, WAITING_APPLICANT, DONE, REJECT, CANCEL
```
```
변경 후
WAITING_REGISTER_APPROVE, DONE, REJECT, CANCEL
```

**목적**
컴포넌트 재사용성 및 로직 단순화를 위한 기획 변경
```
기존
리크루트 참여자는 등록자의 수락을 받고, 이후 최종적으로 자신이 참여 확정을 누름으로써 리쿠르트 모집글에 참여한다.
```

```
변경
리크루트 참여자는 등록자가 수락하는 경우, 리쿠르트 모집글에 참여한다.
리크루트 등록자는 참여 확정이 된 리크루트 참여자를 참여자 명단에서 수정할 수 있다.(추방할 수 있어야한다.)
참여 대기중이거나, 확정이 되지 않은 리크루트글에 대해 사용자는 거절당한 이후에 다시 리크루트 참여를 신청할 수 있다.
```
<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
