### PR TITLE
feat: 리크루트 조회 api 일괄 추가 작업

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
@@ -63,7 +63,7 @@ public class RecruitController {
                 .build();
     }
 
-    @GetMapping("/scraped")
+    @GetMapping("/my-scrap")
     public EnvelopeResponse<GetRecruitsResDto> getScrapedRecruits(Long cursor, Pageable pageable, @Authentication AuthenticatedMember memberInfo) {
         return EnvelopeResponse.<GetRecruitsResDto>builder()
                 .data(recruitService.getScrapedRecruits(memberInfo == null ? null : memberInfo.getMemberId(), cursor, pageable))

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
@@ -69,4 +69,11 @@ public class RecruitController {
                 .data(recruitService.getScrapedRecruits(memberInfo == null ? null : memberInfo.getMemberId(), cursor, pageable))
                 .build();
     }
+
+    @GetMapping("/joined")
+    public  EnvelopeResponse<GetRecruitsResDto> getMemberJoinedRecruits(GetMemberJoinRecruitsReqDto getMemberJoinRecruitsReqDto, @Authentication AuthenticatedMember memberInfo) {
+        return EnvelopeResponse.<GetRecruitsResDto>builder()
+                .data(recruitService.getMemberJoinRecruits(getMemberJoinRecruitsReqDto, memberInfo == null ? null : memberInfo.getMemberId()))
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
@@ -59,21 +59,21 @@ public class RecruitController {
     @GetMapping
     public EnvelopeResponse<GetRecruitsResDto> getRecruits(GetRecruitsReqDto getRecruitsReqDto, Pageable pageable, @Authentication AuthenticatedMember memberInfo) {
         return EnvelopeResponse.<GetRecruitsResDto>builder()
-                .data(recruitService.getRecruits(getRecruitsReqDto, pageable, memberInfo == null ? null : memberInfo.getMemberId()))
+                .data(recruitService.getRecruits(getRecruitsReqDto, pageable, memberInfo.getMemberId()))
                 .build();
     }
 
     @GetMapping("/my-scrap")
     public EnvelopeResponse<GetRecruitsResDto> getScrapedRecruits(Long cursor, Pageable pageable, @Authentication AuthenticatedMember memberInfo) {
         return EnvelopeResponse.<GetRecruitsResDto>builder()
-                .data(recruitService.getScrapedRecruits(memberInfo == null ? null : memberInfo.getMemberId(), cursor, pageable))
+                .data(recruitService.getScrapedRecruits(memberInfo.getMemberId(), cursor, pageable))
                 .build();
     }
 
     @GetMapping("/joined")
     public  EnvelopeResponse<GetRecruitsResDto> getMemberJoinedRecruits(GetMemberJoinRecruitsReqDto getMemberJoinRecruitsReqDto, @Authentication AuthenticatedMember memberInfo) {
         return EnvelopeResponse.<GetRecruitsResDto>builder()
-                .data(recruitService.getMemberJoinRecruits(getMemberJoinRecruitsReqDto, memberInfo == null ? null : memberInfo.getMemberId()))
+                .data(recruitService.getMemberJoinRecruits(getMemberJoinRecruitsReqDto, memberInfo.getMemberId()))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitController.java
@@ -76,4 +76,11 @@ public class RecruitController {
                 .data(recruitService.getMemberJoinRecruits(getMemberJoinRecruitsReqDto, memberInfo.getMemberId()))
                 .build();
     }
+
+    @GetMapping("/applied")
+    public EnvelopeResponse<GetMemberAppliedRecruitsResDto> getMemberAppliedRecruits(GetMemberAppliedRecruitsReqDto recruitsReqDto, @Authentication AuthenticatedMember memberInfo) {
+        return EnvelopeResponse.<GetMemberAppliedRecruitsResDto>builder()
+                .data(recruitService.getMemberAppliedRecruits(recruitsReqDto, 1L))
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/AddParticipantDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/AddParticipantDto.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.recruit.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public interface AddParticipantDto {
+    List<Long> getRecruitsId();
+    Map<Long, Map<String, RecruitParticipant>> getRecruitParticipantMapByRecruitIdAndRecruitType();
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/AppliedRecruit.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/AppliedRecruit.java
@@ -1,0 +1,20 @@
+package com.ssafy.ssafsound.domain.recruit.dto;
+
+import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
+import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppliedRecruit {
+    private Recruit recruit;
+    private MatchStatus matchStatus;
+    private LocalDateTime appliedAt;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/AppliedRecruitElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/AppliedRecruitElement.java
@@ -1,0 +1,42 @@
+package com.ssafy.ssafsound.domain.recruit.dto;
+
+import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AppliedRecruitElement extends RecruitElement {
+
+    private MatchStatus matchStatus;
+    private LocalDateTime appliedAt;
+
+    public static AppliedRecruitElement fromRecruitAndLoginMemberId(AppliedRecruit appliedRecruit, Long memberId) {
+        AppliedRecruitElement appliedRecruitElement = new AppliedRecruitElement(RecruitElement.fromRecruitAndLoginMemberId(appliedRecruit.getRecruit(), memberId));
+        appliedRecruitElement.setMatchStatus(appliedRecruit.getMatchStatus());
+        appliedRecruitElement.setAppliedAt(appliedRecruit.getAppliedAt());
+        return appliedRecruitElement;
+    }
+
+    private AppliedRecruitElement(RecruitElement recruitElement) {
+        super(recruitElement.getRecruitId(),
+                recruitElement.getCategory(),
+                recruitElement.getTitle(),
+                recruitElement.isFinishedRecruit(),
+                recruitElement.getRecruitEnd(),
+                recruitElement.getContent(),
+                recruitElement.getSkills(),
+                recruitElement.getParticipants(),
+                recruitElement.getMine());
+    }
+
+    private void setAppliedAt(LocalDateTime appliedAt) {
+        this.appliedAt = appliedAt;
+    }
+
+    private void setMatchStatus(MatchStatus matchStatus) {
+        this.matchStatus = matchStatus;
+    }
+
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetMemberAppliedRecruitsReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetMemberAppliedRecruitsReqDto.java
@@ -1,0 +1,13 @@
+package com.ssafy.ssafsound.domain.recruit.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetMemberAppliedRecruitsReqDto {
+    private String category;
+    private String matchStatus;
+    private Long cursor;
+    private Integer size;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetMemberAppliedRecruitsResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetMemberAppliedRecruitsResDto.java
@@ -13,36 +13,36 @@ import java.util.stream.Collectors;
 
 @Getter
 @Builder
-public class GetRecruitsResDto implements AddParticipantDto {
-    private List<RecruitElement> recruits;
+public class GetMemberAppliedRecruitsResDto implements AddParticipantDto {
+    private List<AppliedRecruitElement> recruits;
     private Long nextCursor;
     private Boolean isLast;
 
     @JsonIgnore
     public List<Long> getRecruitsId() {
-        return recruits.stream().map(RecruitElement::getRecruitId).collect(Collectors.toList());
+        return recruits.stream().map(AppliedRecruitElement::getRecruitId).collect(Collectors.toList());
     }
 
     @JsonIgnore
     public Map<Long, Map<String, RecruitParticipant>> getRecruitParticipantMapByRecruitIdAndRecruitType() {
         Map<Long, Map<String, RecruitParticipant>> result = new TreeMap<>();
-        for(RecruitElement recruitElement: recruits) {
+        for(AppliedRecruitElement recruitElement: recruits) {
             result.put(recruitElement.getRecruitId(), recruitElement.getRecruitParticipantMap());
         }
         return result;
     }
 
-    public static GetRecruitsResDto fromPageAndMemberId(Slice<Recruit> sliceRecruit, Long memberId) {
-        List<RecruitElement> recruits = sliceRecruit.toList()
+    public static GetMemberAppliedRecruitsResDto fromPageAndMemberId(Slice<AppliedRecruit> appliedRecruitSlice, Long memberId) {
+        List<AppliedRecruitElement> recruits = appliedRecruitSlice.toList()
                 .stream()
-                .map((recruit -> RecruitElement.fromRecruitAndLoginMemberId(recruit, memberId)))
+                .map((appliedRecruit -> AppliedRecruitElement.fromRecruitAndLoginMemberId(appliedRecruit, memberId)))
                 .collect(Collectors.toList());
         Long nextCursor = recruits.isEmpty() ? -1L : recruits.get(recruits.size()-1).getRecruitId();
 
-        return GetRecruitsResDto.builder()
+        return GetMemberAppliedRecruitsResDto.builder()
                 .recruits(recruits)
                 .nextCursor(nextCursor)
-                .isLast(sliceRecruit.isLast())
+                .isLast(appliedRecruitSlice.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetMemberJoinRecruitsReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetMemberJoinRecruitsReqDto.java
@@ -1,0 +1,13 @@
+package com.ssafy.ssafsound.domain.recruit.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetMemberJoinRecruitsReqDto {
+    private Long cursor;
+    private Integer size;
+    private Long memberId;
+    private String category;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitsReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitsReqDto.java
@@ -11,7 +11,6 @@ import java.util.List;
 @Builder
 public class GetRecruitsReqDto {
     private Long cursor;
-    private Long memberId;
 
     @NotBlank
     private String category;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/exception/RecruitErrorInfo.java
@@ -16,7 +16,8 @@ public enum RecruitErrorInfo {
     NOT_BELOW_PREV_LIMITATIONS("909", "스터디/프로젝트 인원은 감소할 수 없습니다."),
     NOT_FOUND_RECRUIT("910", "모집글을 찾을 수 없습니다."),
     NOT_FOUND_RECRUIT_COMMENT("911", "모집글 QNA를 찾을 수 없습니다."),
-    PREV_EXIST_MEMBER_APPLICATION("912", "이미 신청한 스터디/프로젝트 입니다.");
+    PREV_EXIST_MEMBER_APPLICATION("912", "이미 신청한 스터디/프로젝트 입니다."),
+    NOT_VALID_REGISTER_READ_REJECT_REQUEST("913", "유효하지 않은 리크루트 거절 목록 조회 요청 입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitDynamicQueryRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitDynamicQueryRepository.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.recruit.repository;
 
 import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
+import com.ssafy.ssafsound.domain.recruit.dto.AppliedRecruit;
 import com.ssafy.ssafsound.domain.recruit.dto.GetRecruitsReqDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -9,4 +10,6 @@ public interface RecruitDynamicQueryRepository {
     Slice<Recruit> findRecruitByGetRecruitsReqDto(GetRecruitsReqDto dto, Pageable pageable);
     Slice<Recruit> findMemberJoinRecruitWithCursorAndPageable(Long memberId, String category, Long cursorId, Pageable pageable);
     Slice<Recruit> findMemberScrapRecruits(Long memberId, Long cursorId, Pageable pageable);
+
+    Slice<AppliedRecruit> findMemberAppliedRecruits(Long memberId, Long cursor, String category, String matchStatus, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitDynamicQueryRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitDynamicQueryRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Slice;
 
 public interface RecruitDynamicQueryRepository {
     Slice<Recruit> findRecruitByGetRecruitsReqDto(GetRecruitsReqDto dto, Pageable pageable);
-    Slice<Recruit> findMemberJoinRecruitWithCursorAndPageable(Long memberId, Long cursorId, Pageable pageable);
+    Slice<Recruit> findMemberJoinRecruitWithCursorAndPageable(Long memberId, String category, Long cursorId, Pageable pageable);
     Slice<Recruit> findMemberScrapRecruits(Long memberId, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
@@ -172,7 +172,24 @@ public class RecruitService {
         return recruitsResDto;
     }
 
-    private void addRecruitParticipants(GetRecruitsResDto recruitsResDto) {
+    @Transactional
+    public GetMemberAppliedRecruitsResDto getMemberAppliedRecruits(GetMemberAppliedRecruitsReqDto recruitsReqDto, Long memberId) {
+        memberRepository.findById(memberId).orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
+
+        Slice<AppliedRecruit> appliedRecruitSlice = recruitRepository.findMemberAppliedRecruits(memberId,
+                recruitsReqDto.getCursor(),
+                recruitsReqDto.getCategory(),
+                recruitsReqDto.getMatchStatus(),
+                Pageable.ofSize(recruitsReqDto.getSize()));
+
+        GetMemberAppliedRecruitsResDto recruitsResDto = GetMemberAppliedRecruitsResDto.fromPageAndMemberId(appliedRecruitSlice, memberId);
+        if(!recruitsResDto.getRecruits().isEmpty()) {
+            addRecruitParticipants(recruitsResDto);
+        }
+        return recruitsResDto;
+    }
+
+    private void addRecruitParticipants(AddParticipantDto recruitsResDto) {
         // Recruit Id, Recruit Type 두 depth로 이루어진 Map으로 리크루트별 참여자 목록을 가공한다.
         Map<Long, Map<String, RecruitParticipant>> participantsMap = recruitsResDto.getRecruitParticipantMapByRecruitIdAndRecruitType();
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
@@ -21,6 +21,7 @@ import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicati
 import com.ssafy.ssafsound.global.common.exception.GlobalErrorInfo;
 import com.ssafy.ssafsound.global.common.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -129,22 +130,8 @@ public class RecruitService {
     @Transactional(readOnly = true)
     public GetRecruitsResDto getRecruits(GetRecruitsReqDto getRecruitsReqDto, Pageable pageable, Long loginMemberId) {
         // 페이지네이션 조건에 따라 프로젝트/스터디 글 목록을 조회한다.
-        Slice<Recruit> recruitPages;
-        Long memberId = getRecruitsReqDto.getMemberId();
-
-        // 사용자 Id 여부로 프로필, 사용자가 참여한 리크루트 목록 조회, 일반 글 목록 조회를 구분한다.
-        if(memberId != null) {
-            Member member = memberRepository.findById(memberId).orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
-            if(!member.getPublicProfile() && !memberId.equals(loginMemberId)) {
-                throw new MemberException(MemberErrorInfo.MEMBER_PROFILE_SECRET);
-            }
-
-            recruitPages = recruitRepository.findMemberJoinRecruitWithCursorAndPageable(memberId, getRecruitsReqDto.getCursor(), pageable);
-        } else {
-            recruitPages = recruitRepository.findRecruitByGetRecruitsReqDto(getRecruitsReqDto, pageable);
-        }
-
-        GetRecruitsResDto recruitsResDto = GetRecruitsResDto.fromPageAndMemberId(recruitPages, memberId);
+        Slice<Recruit> recruitPages = recruitRepository.findRecruitByGetRecruitsReqDto(getRecruitsReqDto, pageable);
+        GetRecruitsResDto recruitsResDto = GetRecruitsResDto.fromPageAndMemberId(recruitPages, loginMemberId);
         if(!recruitsResDto.getRecruits().isEmpty()) {
             addRecruitParticipants(recruitsResDto);
         }
@@ -167,6 +154,22 @@ public class RecruitService {
             throw new RecruitException(RecruitErrorInfo.INVALID_CHANGE_MEMBER_OPERATION);
         }
         recruit.expired();
+    }
+
+    @Transactional(readOnly = true)
+    public GetRecruitsResDto getMemberJoinRecruits(GetMemberJoinRecruitsReqDto recruitsReqDto, Long loginMemberId) {
+        Long memberId = recruitsReqDto.getMemberId();
+        Member member = memberRepository.findById(memberId).orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
+        if(!member.getPublicProfile()) {
+            throw new MemberException(MemberErrorInfo.MEMBER_PROFILE_SECRET);
+        }
+
+        Slice<Recruit> recruitPages = recruitRepository.findMemberJoinRecruitWithCursorAndPageable(memberId, recruitsReqDto.getCategory(), recruitsReqDto.getCursor(), PageRequest.ofSize(recruitsReqDto.getSize()));
+        GetRecruitsResDto recruitsResDto = GetRecruitsResDto.fromPageAndMemberId(recruitPages, loginMemberId);
+        if(!recruitsResDto.getRecruits().isEmpty()) {
+            addRecruitParticipants(recruitsResDto);
+        }
+        return recruitsResDto;
     }
 
     private void addRecruitParticipants(GetRecruitsResDto recruitsResDto) {

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -77,7 +77,14 @@ public class RecruitApplicationController {
     @GetMapping("/recruit-applications/rejected")
     public EnvelopeResponse<GetRecruitApplicationsResDto> getRejectedRecruitApplicationByRecruitId(Long recruitId, @Authentication AuthenticatedMember authenticatedMember) {
         return EnvelopeResponse.<GetRecruitApplicationsResDto>builder()
-                .data(recruitApplicationService.getRejectedRecruitApplicationByRecruitId(recruitId, authenticatedMember == null ? null : authenticatedMember.getMemberId()))
+                .data(recruitApplicationService.getRejectedRecruitApplicationByRecruitId(recruitId, authenticatedMember.getMemberId()))
+                .build();
+    }
+
+    @GetMapping("/recruit-applications/mine")
+    public EnvelopeResponse<GetRecruitApplicationDetailResDto> getRecentPendingRecruitApplicationByRecruitId(Long recruitId, @Authentication AuthenticatedMember authenticatedMember) {
+        return EnvelopeResponse.<GetRecruitApplicationDetailResDto>builder()
+                .data(recruitApplicationService.getRecentPendingRecruitApplicationByRecruitId(recruitId, authenticatedMember.getMemberId()))
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationController.java
@@ -73,4 +73,11 @@ public class RecruitApplicationController {
                 .data(recruitApplicationService.getRecruitApplicationByIdAndRegisterId(recruitApplicationId, authenticatedMember.getMemberId()))
                 .build();
     }
+
+    @GetMapping("/recruit-applications/rejected")
+    public EnvelopeResponse<GetRecruitApplicationsResDto> getRejectedRecruitApplicationByRecruitId(Long recruitId, @Authentication AuthenticatedMember authenticatedMember) {
+        return EnvelopeResponse.<GetRecruitApplicationsResDto>builder()
+                .data(recruitApplicationService.getRejectedRecruitApplicationByRecruitId(recruitId, authenticatedMember == null ? null : authenticatedMember.getMemberId()))
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationComplexQueryRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationComplexQueryRepository.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafsound.domain.recruitapplication.repository;
+
+import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
+
+public interface RecruitApplicationComplexQueryRepository {
+    RecruitApplicationElement findTopByRecruitIdAndMemberId(Long recruitId, Long memberId);
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationComplexQueryRepositoryImpl.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationComplexQueryRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.ssafy.ssafsound.domain.recruitapplication.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
+import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
+import com.ssafy.ssafsound.global.common.exception.GlobalErrorInfo;
+import com.ssafy.ssafsound.global.common.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import static com.ssafy.ssafsound.domain.member.domain.QMember.member;
+import static com.ssafy.ssafsound.domain.recruit.domain.QRecruit.recruit;
+import static com.ssafy.ssafsound.domain.recruitapplication.domain.QRecruitApplication.recruitApplication;
+import static com.ssafy.ssafsound.domain.recruit.domain.QRecruitQuestion.recruitQuestion;
+import static com.ssafy.ssafsound.domain.recruit.domain.QRecruitQuestionReply.recruitQuestionReply;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class RecruitApplicationComplexQueryRepositoryImpl implements RecruitApplicationComplexQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    @Override
+    public RecruitApplicationElement findTopByRecruitIdAndMemberId(Long recruitId, Long memberId) {
+        try {
+            return jpaQueryFactory.select(
+                            Projections
+                                    .fields(
+                                            RecruitApplicationElement.class,
+                                            recruit.id,
+                                            recruitApplication.id,
+                                            recruitApplication.matchStatus,
+                                            member,
+                                            recruitQuestionReply.content,
+                                            recruitQuestion.content,
+                                            recruitApplication.isLike,
+                                            recruitApplication.createdAt,
+                                            recruitApplication.modifiedAt
+                                    ))
+                    .from(recruitApplication)
+                    .innerJoin(recruitApplication.member, member)
+                    .innerJoin(recruitApplication.recruit, recruit)
+                    .join(recruitQuestion).on(recruitQuestion.recruit.id.eq(recruit.id))
+                    .join(recruitQuestionReply).on(recruitQuestionReply.question.id.eq(recruitQuestion.id))
+                    .where(recruit.id.eq(recruitId), member.id.eq(memberId), recruitApplication.matchStatus.eq(MatchStatus.PENDING))
+                    .orderBy(recruitApplication.id.desc())
+                    .limit(1)
+                    .fetchOne();
+        } catch (Exception e) {
+            throw new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -4,6 +4,7 @@ import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -28,8 +28,8 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
             "inner join r.member as m " +
             "left outer join recruit_question_reply as rp on r.id = rp.application.id " +
             "left outer join rp.question as rq " +
-            "where r.recruit.id = :recruitId and r.recruit.member.id = :registerId and r.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.PENDING")
-    List<RecruitApplicationElement> findByRecruitIdAndRegisterMemberIdWithQuestionReply(Long recruitId, Long registerId);
+            "where r.recruit.id = :recruitId and r.recruit.member.id = :registerId and r.matchStatus = :matchStatus")
+    List<RecruitApplicationElement> findByRecruitIdAndRegisterMemberAndMatchStatusIdWithQuestionReply(Long recruitId, Long registerId, MatchStatus matchStatus);
 
     @Query("SELECT new com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement(r.recruit.id, r.id, r.type, r.matchStatus, m, rp.content, rq.content, r.isLike, r.createdAt, r.modifiedAt) from recruit_application r  " +
             "inner join r.member as m " +

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -1,5 +1,7 @@
 package com.ssafy.ssafsound.domain.recruitapplication.service;
 
+import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
+import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberRepository;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
@@ -17,12 +19,14 @@ import com.ssafy.ssafsound.domain.recruit.repository.RecruitRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus;
 import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.*;
+import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicationComplexQueryRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicationRepository;
 import com.ssafy.ssafsound.domain.recruitapplication.validator.RecruitApplicationValidator;
 import com.ssafy.ssafsound.domain.recruitcomment.dto.PostRecruitApplicationLikeResDto;
 import com.ssafy.ssafsound.global.common.exception.GlobalErrorInfo;
 import com.ssafy.ssafsound.global.common.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -37,6 +41,7 @@ public class RecruitApplicationService {
     private final RecruitRepository recruitRepository;
     private final RecruitQuestionReplyRepository recruitQuestionReplyRepository;
     private final RecruitApplicationRepository recruitApplicationRepository;
+    private final RecruitApplicationComplexQueryRepository recruitApplicationComplexQueryRepository;
     private final RecruitLimitationRepository recruitLimitationRepository;
     private final MemberRepository memberRepository;
     private final MetaDataConsumer metaDataConsumer;
@@ -148,6 +153,12 @@ public class RecruitApplicationService {
             throw new RecruitException(RecruitErrorInfo.NOT_VALID_REGISTER_READ_REJECT_REQUEST);
         }
         return new GetRecruitApplicationsResDto(recruit, recruitApplicationRepository.findByRecruitIdAndRegisterMemberAndMatchStatusIdWithQuestionReply(recruitId, memberId, MatchStatus.REJECT));
+    }
+
+    @Transactional(readOnly = true)
+    public GetRecruitApplicationDetailResDto getRecentPendingRecruitApplicationByRecruitId(Long recruitId, Long memberId) {
+//        memberRepository.findById(memberId).orElseThrow(()->new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+        return new GetRecruitApplicationDetailResDto(recruitApplicationComplexQueryRepository.findTopByRecruitIdAndMemberId(recruitId, 2L));
     }
 
     private boolean isPrevExistWaitingOrDoneMember(Long recruitId, Long memberId) {

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -121,7 +121,7 @@ public class RecruitApplicationService {
     @Transactional(readOnly = true)
     public GetRecruitApplicationsResDto getRecruitApplications(Long recruitId, Long memberId) {
         Recruit recruit = recruitRepository.findById(recruitId).orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
-        return new GetRecruitApplicationsResDto(recruit, recruitApplicationRepository.findByRecruitIdAndRegisterMemberIdWithQuestionReply(recruitId, memberId));
+        return new GetRecruitApplicationsResDto(recruit, recruitApplicationRepository.findByRecruitIdAndRegisterMemberAndMatchStatusIdWithQuestionReply(recruitId, memberId, MatchStatus.PENDING));
     }
 
     @Transactional
@@ -138,6 +138,16 @@ public class RecruitApplicationService {
     @Transactional(readOnly = true)
     public GetRecruitApplicationDetailResDto getRecruitApplicationByIdAndRegisterId(Long recruitApplicationId, Long registerId) {
         return new GetRecruitApplicationDetailResDto(recruitApplicationRepository.findByRecruitApplicationIdAndRegisterId(recruitApplicationId, registerId));
+    }
+
+    @Transactional(readOnly = true)
+    public GetRecruitApplicationsResDto getRejectedRecruitApplicationByRecruitId(Long recruitId, Long memberId) {
+        Recruit recruit = recruitRepository.findByIdFetchJoinRegister(recruitId);
+
+        if(recruit==null || !recruit.getMember().getId().equals(memberId)) {
+            throw new RecruitException(RecruitErrorInfo.NOT_VALID_REGISTER_READ_REJECT_REQUEST);
+        }
+        return new GetRecruitApplicationsResDto(recruit, recruitApplicationRepository.findByRecruitIdAndRegisterMemberAndMatchStatusIdWithQuestionReply(recruitId, memberId, MatchStatus.REJECT));
     }
 
     private boolean isPrevExistWaitingOrDoneMember(Long recruitId, Long memberId) {

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationService.java
@@ -157,8 +157,8 @@ public class RecruitApplicationService {
 
     @Transactional(readOnly = true)
     public GetRecruitApplicationDetailResDto getRecentPendingRecruitApplicationByRecruitId(Long recruitId, Long memberId) {
-//        memberRepository.findById(memberId).orElseThrow(()->new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
-        return new GetRecruitApplicationDetailResDto(recruitApplicationComplexQueryRepository.findTopByRecruitIdAndMemberId(recruitId, 2L));
+        memberRepository.findById(memberId).orElseThrow(()->new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
+        return new GetRecruitApplicationDetailResDto(recruitApplicationComplexQueryRepository.findTopByRecruitIdAndMemberId(recruitId, memberId));
     }
 
     private boolean isPrevExistWaitingOrDoneMember(Long recruitId, Long memberId) {

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
@@ -242,4 +242,49 @@ public class RecruitControllerTest extends ControllerTest {
                         )
                 );
     }
+
+    @DisplayName("스크랩 된 리크루트 목록 조회")
+    @Test
+    void getScrapedRecruits() {
+        doReturn(RecruitFixture.GET_RECRUITS_RES_DTO)
+                .when(recruitService)
+                .getScrapedRecruits(any(), any(), any());
+
+        restDocs
+                .cookie(ACCESS_TOKEN)
+                .when().get("/recruits/my-scrap?size=10")
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("recruit/my-scrap",
+                        requestCookieAccessTokenMandatory(),
+                        requestParameters(
+                                parameterWithName("cursor").optional().description("다음 조회 커서 default(초기화면)에서는 미포함"),
+                                parameterWithName("size").description("페이징 사이즈")
+                        ),
+                        getEnvelopPatternWithData().andWithPrefix("data.",
+                                fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).description("다음 조회할 커서 번호"),
+                                fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부")
+                        ).andWithPrefix("data.recruits[].",
+                                fieldWithPath("recruitId").type(JsonFieldType.NUMBER).description("리크루트 id"),
+                                fieldWithPath("category").type(JsonFieldType.STRING).description("카테고리 project|study"),
+                                fieldWithPath("mine").type(JsonFieldType.BOOLEAN).description("내가 쓴 글 여부(토큰 기준)"),
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("리크루트 모집글 제목, 글자 수 제한 50자"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("리크루트 본문 요약본 최대 50자"),
+                                fieldWithPath("recruitEnd").type(JsonFieldType.STRING).description("yyyy-MM-dd 모집 종료 일자"),
+                                fieldWithPath("finishedRecruit").type(JsonFieldType.BOOLEAN).description("리크루트 종료 여부"),
+                                fieldWithPath("participants[].members[]").type(JsonFieldType.ARRAY).description("리크루트 참여 멤버 ").optional()
+                        ).andWithPrefix("data.recruits[].skills[].",
+                                fieldWithPath("skillId").type(JsonFieldType.NUMBER).description("스킬 id 미사용"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("리크루트와 연관된 기술 스택명, 메타데이터-스킬 목록 조회 참고")
+                        ).andWithPrefix("data.recruits[].participants[].",
+                                fieldWithPath("recruitType").type(JsonFieldType.STRING).description("리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고"),
+                                fieldWithPath("limit").type(JsonFieldType.NUMBER).description("리크루트 모집 인원 제한 1명이상 10명 이하")
+                        ).andWithPrefix("data.recruits[].participants[].members[].",
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("리크루트 참여자 닉네임"),
+                                fieldWithPath("major").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
+                        )
+                )
+            );
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
@@ -333,4 +333,53 @@ public class RecruitControllerTest extends ControllerTest {
                         )
                 );
     }
+
+    @DisplayName("내가 신청한 리크루트 상태별 목록 조회")
+    @Test
+    void getAppiedRecruits() {
+        doReturn(RecruitFixture.GET_MEMBER_APPLIED_RECRUITS_RES_DTO)
+                .when(recruitService)
+                .getMemberAppliedRecruits(any(), any());
+
+        restDocs
+                .cookie(ACCESS_TOKEN)
+                .when().get("/recruits/applied?size=10&category=project")
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("recruit/applied-recruits",
+                                requestCookieAccessTokenMandatory(),
+                                requestParameters(
+                                        parameterWithName("cursor").optional().description("다음 조회 커서 default(초기화면)에서는 미포함"),
+                                        parameterWithName("size").description("페이징 사이즈"),
+                                        parameterWithName("category").description("카테고리 project|study"),
+                                        parameterWithName("matchStatus").optional().description("리크루트 게시글 제목 검색 키워드")
+                                ),
+                                getEnvelopPatternWithData().andWithPrefix("data.",
+                                        fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).description("다음 조회할 커서 번호"),
+                                        fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부")
+                                ).andWithPrefix("data.recruits[].",
+                                        fieldWithPath("recruitId").type(JsonFieldType.NUMBER).description("리크루트 id"),
+                                        fieldWithPath("category").type(JsonFieldType.STRING).description("카테고리 project|study"),
+                                        fieldWithPath("mine").type(JsonFieldType.BOOLEAN).description("내가 쓴 글 여부(토큰 기준)"),
+                                        fieldWithPath("title").type(JsonFieldType.STRING).description("리크루트 모집글 제목, 글자 수 제한 50자"),
+                                        fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("사용자 리크루트 매칭 상태"),
+                                        fieldWithPath("appliedAt").type(JsonFieldType.STRING).description("사용자 리크루트 신청일"),
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("리크루트 본문 요약본 최대 50자"),
+                                        fieldWithPath("recruitEnd").type(JsonFieldType.STRING).description("yyyy-MM-dd 모집 종료 일자"),
+                                        fieldWithPath("finishedRecruit").type(JsonFieldType.BOOLEAN).description("리크루트 종료 여부"),
+                                        fieldWithPath("participants[].members[]").type(JsonFieldType.ARRAY).description("리크루트 참여 멤버 ").optional()
+                                ).andWithPrefix("data.recruits[].skills[].",
+                                        fieldWithPath("skillId").type(JsonFieldType.NUMBER).description("스킬 id 미사용"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("리크루트와 연관된 기술 스택명, 메타데이터-스킬 목록 조회 참고")
+                                ).andWithPrefix("data.recruits[].participants[].",
+                                        fieldWithPath("recruitType").type(JsonFieldType.STRING).description("리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고"),
+                                        fieldWithPath("limit").type(JsonFieldType.NUMBER).description("리크루트 모집 인원 제한 1명이상 10명 이하")
+                                ).andWithPrefix("data.recruits[].participants[].members[].",
+                                        fieldWithPath("nickname").type(JsonFieldType.STRING).description("리크루트 참여자 닉네임"),
+                                        fieldWithPath("major").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
+                                )
+                        )
+                );
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
@@ -214,8 +214,7 @@ public class RecruitControllerTest extends ControllerTest {
                                 parameterWithName("keyword").description("리크루트 게시글 제목 검색 키워드"),
                                 parameterWithName("isFinished").description("리크루트 종료 여부"),
                                 parameterWithName("recruitTypes").description("리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고"),
-                                parameterWithName("skills").description("리크루트와 연관된 기술 스택, 메타데이터-스킬 목록 조회 참고"),
-                                parameterWithName("memberId").optional().description("사용자 프로필 - 참여중인 리크루트 목록 조회 시 사용될 사용자의 Id")
+                                parameterWithName("skills").description("리크루트와 연관된 기술 스택, 메타데이터-스킬 목록 조회 참고")
                         ),
                         getEnvelopPatternWithData().andWithPrefix("data.",
                                 fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).description("다음 조회할 커서 번호"),
@@ -286,5 +285,52 @@ public class RecruitControllerTest extends ControllerTest {
                         )
                 )
             );
+    }
+
+    @DisplayName("사용자 참여 확정 리크루트 목록 조회")
+    @Test
+    void getMemberJoinedRecruits() {
+        doReturn(RecruitFixture.GET_RECRUITS_RES_DTO)
+                .when(recruitService)
+                .getMemberJoinRecruits(any(), any());
+
+        restDocs
+                .cookie(ACCESS_TOKEN)
+                .when().get("/recruits/joined?memberId=1&category=PROJECT&size=10")
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("recruit/joined",
+                                requestCookieAccessTokenOptional(),
+                                requestParameters(
+                                        parameterWithName("cursor").optional().description("다음 조회 커서 default(초기화면)에서는 미포함"),
+                                        parameterWithName("size").description("페이징 사이즈"),
+                                        parameterWithName("category").description("카테고리 project|study"),
+                                        parameterWithName("memberId").description("사용자 프로필 - 참여중인 리크루트 목록 조회 시 사용될 사용자의 Id")
+                                ),
+                                getEnvelopPatternWithData().andWithPrefix("data.",
+                                        fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).description("다음 조회할 커서 번호"),
+                                        fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부")
+                                ).andWithPrefix("data.recruits[].",
+                                        fieldWithPath("recruitId").type(JsonFieldType.NUMBER).description("리크루트 id"),
+                                        fieldWithPath("category").type(JsonFieldType.STRING).description("카테고리 project|study"),
+                                        fieldWithPath("mine").type(JsonFieldType.BOOLEAN).description("내가 쓴 글 여부(토큰 기준)"),
+                                        fieldWithPath("title").type(JsonFieldType.STRING).description("리크루트 모집글 제목, 글자 수 제한 50자"),
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("리크루트 본문 요약본 최대 50자"),
+                                        fieldWithPath("recruitEnd").type(JsonFieldType.STRING).description("yyyy-MM-dd 모집 종료 일자"),
+                                        fieldWithPath("finishedRecruit").type(JsonFieldType.BOOLEAN).description("리크루트 종료 여부"),
+                                        fieldWithPath("participants[].members[]").type(JsonFieldType.ARRAY).description("리크루트 참여 멤버 ").optional()
+                                ).andWithPrefix("data.recruits[].skills[].",
+                                        fieldWithPath("skillId").type(JsonFieldType.NUMBER).description("스킬 id 미사용"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("리크루트와 연관된 기술 스택명, 메타데이터-스킬 목록 조회 참고")
+                                ).andWithPrefix("data.recruits[].participants[].",
+                                        fieldWithPath("recruitType").type(JsonFieldType.STRING).description("리크루트 모집파트, 메타데이터-리크루트 목록 조회 참고"),
+                                        fieldWithPath("limit").type(JsonFieldType.NUMBER).description("리크루트 모집 인원 제한 1명이상 10명 이하")
+                                ).andWithPrefix("data.recruits[].participants[].members[].",
+                                        fieldWithPath("nickname").type(JsonFieldType.STRING).description("리크루트 참여자 닉네임"),
+                                        fieldWithPath("major").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
+                                )
+                        )
+                );
     }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/service/RecruitServiceTest.java
@@ -436,4 +436,10 @@ class RecruitServiceTest {
     void Given_MemberId_When_GetScrapedRecruits_Then_Success() {
         // TODO Test Refactoring 시 일괄 작성
     }
+
+    @DisplayName("사용자 프로필 - 사용자 신청한 리크루트 조회")
+    @Test
+    void Given_MemberIdCategoryMatchStatus_GetAppiedRecruits_Then_Success() {
+        // TODO Test Refactoring 시 일괄 작성
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
@@ -268,4 +268,48 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                         )
                 );
     }
+
+    @DisplayName("등록자 거절한 리크루트 신청 목록 조회")
+    @Test
+    void getRejectedRecruit() {
+        doReturn(RecruitApplicationFixture.GET_REJECTED_RECRUIT_APPLICATIONS_RES_DTO)
+                .when(recruitApplicationService)
+                .getRejectedRecruitApplicationByRecruitId(any(), any());
+
+        restDocs
+                .cookie(ACCESS_TOKEN)
+                .when().get("/recruit-applications/rejected?recruitId=1")
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("recruitApplication/register-rejected-applications",
+                                requestCookieAccessTokenMandatory(),
+                                requestParameters(
+                                        parameterWithName("recruitId").description("리크루트 PK")
+                                ),
+                                getEnvelopPatternWithData().andWithPrefix(
+                                        "data.",
+                                        fieldWithPath("recruitId").type(JsonFieldType.NUMBER).description("리크루트 PK"),
+                                        fieldWithPath("category").type(JsonFieldType.STRING).description("PROJECT | STUDY")
+                                ).andWithPrefix("data.recruitApplications.*.[].",
+                                        fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
+                                        fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("매칭 상태 - (PENDING:등록자 수락대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)"),
+                                        fieldWithPath("author.memberId").type(JsonFieldType.NUMBER).description("참여자 PK"),
+                                        fieldWithPath("author.nickname").type(JsonFieldType.STRING).description("참여자 닉네임"),
+                                        fieldWithPath("author.isMajor").type(JsonFieldType.BOOLEAN).description("전공자 여부"),
+                                        fieldWithPath("author.memberRole").type(JsonFieldType.STRING).description("참여자 권한"),
+                                        fieldWithPath("author.ssafyMember").type(JsonFieldType.BOOLEAN).description("싸피 인증 여부"),
+                                        fieldWithPath("question").type(JsonFieldType.STRING).description("등록자 질문"),
+                                        fieldWithPath("reply").type(JsonFieldType.STRING).description("참여자 답변"),
+                                        fieldWithPath("liked").type(JsonFieldType.BOOLEAN).description("등록자 좋아요 여부"),
+                                        fieldWithPath("appliedAt").type(JsonFieldType.STRING).description("참여 신청일")
+                                ).andWithPrefix("data.recruitApplications.*.[].author.ssafyInfo.",
+                                        fieldWithPath("semester").type(JsonFieldType.NUMBER).description("참여자 싸피 기수 (1~10)"),
+                                        fieldWithPath("campus").type(JsonFieldType.STRING).description("참여자 소속 캠퍼스 메타데이터-캠퍼스 목록 조회 참고"),
+                                        fieldWithPath("certificationState").type(JsonFieldType.STRING).description("참여자 ssafy 인증 여부 UNCERTIFIED | CERTIFIED"),
+                                        fieldWithPath("majorTrack").type(JsonFieldType.STRING).description("전공 트랙 Embedded | Mobile | Python | Java")
+                                )
+                        )
+                );
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/controller/RecruitApplicationControllerTest.java
@@ -312,4 +312,45 @@ public class RecruitApplicationControllerTest extends ControllerTest {
                         )
                 );
     }
+
+    @DisplayName("사용자 리크루트 참여 대기 신청 상세 조회")
+    @Test
+    void getRecruitApplicationByRecruitIdAndMemberId() {
+        doReturn(RecruitApplicationFixture.APPLICATION_DETAIL_RES_DTO)
+                .when(recruitApplicationService)
+                .getRecentPendingRecruitApplicationByRecruitId(any(), any());
+
+        restDocs
+                .cookie(ACCESS_TOKEN)
+                .when().get("/recruit-applications/mine?recruitId=1")
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .apply(document("recruitApplication/member-pending-detail",
+                                requestCookieAccessTokenMandatory(),
+                                requestParameters(
+                                        parameterWithName("recruitId").description("리크루트 PK")
+                                ),
+                                getEnvelopPatternWithData().andWithPrefix("data.",
+                                        fieldWithPath("recruitId").type(JsonFieldType.NUMBER).description("리크루트 PK"),
+                                        fieldWithPath("recruitApplicationId").type(JsonFieldType.NUMBER).description("리크루트 참여 신청 PK"),
+                                        fieldWithPath("recruitType").type(JsonFieldType.STRING).description("리크루트 참여 신청자가 선택한 자신의 역할군, 메타데이터-리크루트 목록 조회 참고"),
+                                        fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("매칭 상태 - (PENDING:등록자 수락대기), (DONE:매칭 성공), (REJECT:매칭 거절),  (CANCEL:매칭취소)"),
+                                        fieldWithPath("author.memberId").type(JsonFieldType.NUMBER).description("참여자 PK"),
+                                        fieldWithPath("author.nickname").type(JsonFieldType.STRING).description("참여자 닉네임"),
+                                        fieldWithPath("author.memberRole").type(JsonFieldType.STRING).description("참여자 권한"),
+                                        fieldWithPath("author.isMajor").type(JsonFieldType.BOOLEAN).description("전공자 여부"),
+                                        fieldWithPath("author.ssafyMember").type(JsonFieldType.BOOLEAN).description("싸피 인증 여부"),
+                                        fieldWithPath("question").type(JsonFieldType.STRING).description("등록자 질문"),
+                                        fieldWithPath("reply").type(JsonFieldType.STRING).description("참여자 답변"),
+                                        fieldWithPath("liked").type(JsonFieldType.BOOLEAN).description("등록자 좋아요 여부"),
+                                        fieldWithPath("appliedAt").type(JsonFieldType.STRING).description("신청일")
+                                ).andWithPrefix("data.author.ssafyInfo.",
+                                        fieldWithPath("semester").type(JsonFieldType.NUMBER).description("참여자 싸피 기수 (1~10)"),
+                                        fieldWithPath("campus").type(JsonFieldType.STRING).description("참여자 소속 캠퍼스 메타데이터-캠퍼스 목록 조회 참고"),
+                                        fieldWithPath("certificationState").type(JsonFieldType.STRING).description("참여자 ssafy 인증 여부 UNCERTIFIED | CERTIFIED"),
+                                        fieldWithPath("majorTrack").type(JsonFieldType.STRING).description("전공 트랙 Embedded | Mobile | Python | Java"))
+                        )
+                );
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -303,4 +303,10 @@ class RecruitApplicationServiceTest {
                 ()-> recruitApplicationService.toggleRecruitApplicationLike(1L, 2L)
         );
     }
+
+    @DisplayName("등록자 리크루트 거절 목록 조회")
+    @Test
+    void GivenRecruitIdAndRegisterToken_When_GetRejectedRecruitApplicationThen_Success() {
+        // TODO
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruitapplication/service/RecruitApplicationServiceTest.java
@@ -309,4 +309,10 @@ class RecruitApplicationServiceTest {
     void GivenRecruitIdAndRegisterToken_When_GetRejectedRecruitApplicationThen_Success() {
         // TODO
     }
+
+    @DisplayName("사용자 리크루트 신청 상세 조회")
+    @Test
+    void GivenRecruitIdAndMemberToken_When_GetRecentPendingRecruitApplicationThen_Success() {
+        // TODO
+    }
 }

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitApplicationFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitApplicationFixture.java
@@ -48,10 +48,24 @@ public class RecruitApplicationFixture {
             .modifiedAt(LocalDateTime.now())
             .build();
 
+    public static final RecruitApplicationElement APPLICATION_REJECT_ELEMENT = RecruitApplicationElement.builder()
+            .recruitId(1L)
+            .recruitApplicationId(1L)
+            .recruitType(RecruitType.FRONT_END.getName())
+            .matchStatus(MatchStatus.REJECT)
+            .author(new AuthorElement(MemberFixture.MEMBER_TIM, false))
+            .question(RecruitFixture.RECRUIT_1.getQuestions().get(0).getContent())
+            .reply("취업 준비를 위해서 신청하게되었습니다.")
+            .liked(false)
+            .createdAt(LocalDateTime.now())
+            .modifiedAt(LocalDateTime.now())
+            .build();
+
     public static final GetRecruitApplicationDetailResDto APPLICATION_DETAIL_RES_DTO = new GetRecruitApplicationDetailResDto(APPLICATION1_ELEMENT);
 
     public static final GetRecruitApplicationsResDto GET_RECRUIT_APPLICATIONS_RES_DTO = new GetRecruitApplicationsResDto(RecruitFixture.RECRUIT_1, Arrays.asList(APPLICATION1_ELEMENT));
 
+    public static final GetRecruitApplicationsResDto GET_REJECTED_RECRUIT_APPLICATIONS_RES_DTO = new GetRecruitApplicationsResDto(RecruitFixture.RECRUIT_1, Arrays.asList(APPLICATION_REJECT_ELEMENT));
     public static final GetRecruitParticipantsResDto GET_RECRUIT_PARTICIPANTS_RES_DTO = GetRecruitParticipantsResDto
             .of(List.of(getRecruitApplication1_ByMatchStatus(MatchStatus.DONE, new MetaData(RecruitType.FRONT_END), false)),List.of(RecruitFixture.RECRUIT_1_BE_LIMIT_3, RecruitFixture.RECRUIT_1_FE_LIMIT_3));
 

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitFixture.java
@@ -144,10 +144,23 @@ public class RecruitFixture {
         RECRUIT_1.setRecruitLimitations(List.of(RECRUIT_1_BE_LIMIT_3, RECRUIT_1_FE_LIMIT_3));
     }
 
-    private static final RecruitElement RECRUIT_1_ELEMENT = RecruitElement.fromRecruitAndLoginMemberId(RECRUIT_1, 2L);
+    private static final RecruitElement RECRUIT_1_ELEMENT = RecruitElement.fromRecruitAndLoginMemberId(RECRUIT_1, 1L);
 
     public static final GetRecruitsResDto GET_RECRUITS_RES_DTO = GetRecruitsResDto.builder()
             .recruits(List.of(RECRUIT_1_ELEMENT))
+            .nextCursor(1L)
+            .isLast(true)
+            .build();
+
+    private static final AppliedRecruit APPLIED_RECRUIT = AppliedRecruit.builder()
+            .recruit(RECRUIT_1)
+            .appliedAt(RecruitApplicationFixture.APPLICATION1_ELEMENT.getCreatedAt())
+            .matchStatus(RecruitApplicationFixture.APPLICATION1_ELEMENT.getMatchStatus())
+            .build();
+    private static final AppliedRecruitElement APPLIED_RECRUIT_ELEMENT = AppliedRecruitElement.fromRecruitAndLoginMemberId(APPLIED_RECRUIT, 100L);
+
+    public static final GetMemberAppliedRecruitsResDto GET_MEMBER_APPLIED_RECRUITS_RES_DTO = GetMemberAppliedRecruitsResDto.builder()
+            .recruits(List.of(APPLIED_RECRUIT_ELEMENT))
             .nextCursor(1L)
             .isLast(true)
             .build();


### PR DESCRIPTION
## Issues

- #251

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [x] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 세부 구현 사항 1
 1. 사용자 지원한 리크루트 목록 조회 (-> 리크루팅 목록 조회와 동일, appiedAt, matchStatus 추가) (전체/ 대기중/ 수락됨/ 거절됨)

 2. 사용자 참여중인 리쿠르팅 목록 조회 (-> 리크루팅 목록 조회와 동일한 응답 데이터)

 3. 사용자 리크루팅 신청서 조회 (리크루팅 디테일에서 application 상세조회)

 4. 사용자 스크랩 리크루팅 목록 조회 (-> 리크루팅 목록 조회와 동일한 응답 데이터)

 5. 등록자 거절한 리크루팅 신청 목록 조회 (-> 리크루트 참여 신청 목록 조회와 동일한 응답 데이터)
 
<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

주말 간 배포를 위해 서비스 테스트 코드는 리팩토링과 함께 진행하겠습니다. 
