### PR TITLE
fix: 리크루트 디테일 조회 시 내가 쓴 글 여부 추가 및 목록 조회 전공자 여부 필드명 일괄 수정 

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitDetailResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/GetRecruitDetailResDto.java
@@ -36,8 +36,9 @@ public class GetRecruitDetailResDto {
     private long scrapCount;
     private Boolean scraped;
     private String matchStatus;
+    private Boolean mine;
 
-    public static GetRecruitDetailResDto of(Recruit recruit, long scrapCount, Boolean scraped, RecruitApplication recruitApplication) {
+    public static GetRecruitDetailResDto of(Recruit recruit, long scrapCount, Boolean scraped, Boolean mine, RecruitApplication recruitApplication) {
 
         if(recruit.getDeletedRecruit()) throw new RecruitException(RecruitErrorInfo.IS_DELETED);
 
@@ -76,6 +77,7 @@ public class GetRecruitDetailResDto {
                 .scrapCount(scrapCount)
                 .scraped(scraped)
                 .matchStatus(matchStatus)
+                .mine(mine)
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/Participant.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/dto/Participant.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @Builder
 public class Participant {
     private String nickname;
-    private boolean isMajor;
+    private Boolean isMajor;
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
@@ -75,10 +75,11 @@ public class RecruitService {
                 .orElseThrow(()->new ResourceNotFoundException(GlobalErrorInfo.NOT_FOUND));
         long scrapCount = recruitScrapRepository.countByRecruitId(recruitId);
         Boolean scraped = recruitScrapRepository.existsByRecruitIdAndMemberId(recruitId, memberId);
+        Boolean mine = recruit.getMember().getId().equals(memberId);
 
         RecruitApplication recruitApplication = recruitApplicationRepository.findTopByRecruitIdAndMemberIdOrderByIdDesc(recruitId, memberId);
         recruit.increaseView();
-        return GetRecruitDetailResDto.of(recruit, scrapCount, scraped, recruitApplication);
+        return GetRecruitDetailResDto.of(recruit, scrapCount, scraped, mine, recruitApplication);
     }
 
     @Transactional

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -835,7 +835,7 @@ Content-Length: 954
       "content" : "저도 싸피에서 교육들으면 개발실력 엄청 오르겠죠?",
       "likeCount" : 11,
       "commentCount" : 29,
-      "createdAt" : "2023-09-24T16:23:04.130744",
+      "createdAt" : "2023-09-24T18:56:17.696473",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -847,7 +847,7 @@ Content-Length: 954
       "content" : "역시 B형 특강을 열심히 듣는게 맞나요?",
       "likeCount" : 5,
       "commentCount" : 14,
-      "createdAt" : "2023-09-24T16:23:04.130758",
+      "createdAt" : "2023-09-24T18:56:17.696493",
       "nickname" : "익명",
       "anonymity" : true,
       "thumbnail" : "썸네일 URL"
@@ -1598,7 +1598,7 @@ Content-Length: 491
       "content" : "SSAFY 9기 합격했습니다!!",
       "likeCount" : 3,
       "commentCount" : 2,
-      "createdAt" : "2023-09-24T16:23:04.130764",
+      "createdAt" : "2023-09-24T18:56:17.696499",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2507,7 +2507,7 @@ Content-Length: 909
       "content" : "열심히 SSAFY 9기를 수료하시면 취업에 성공하실겁니다.",
       "likeCount" : 102,
       "commentCount" : 33,
-      "createdAt" : "2023-09-24T16:23:04.130769",
+      "createdAt" : "2023-09-24T18:56:17.696504",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2519,7 +2519,7 @@ Content-Length: 909
       "content" : "은 실력입니다.",
       "likeCount" : 202,
       "commentCount" : 54,
-      "createdAt" : "2023-09-24T16:23:04.130774",
+      "createdAt" : "2023-09-24T18:56:17.696509",
       "nickname" : "익명",
       "anonymity" : true,
       "thumbnail" : "썸네일 URL"
@@ -2711,7 +2711,7 @@ Content-Length: 533
       "content" : "열심히 SSAFY 9기를 수료하시면 취업에 성공하실겁니다.",
       "likeCount" : 102,
       "commentCount" : 33,
-      "createdAt" : "2023-09-24T16:23:04.130769",
+      "createdAt" : "2023-09-24T18:56:17.696504",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2893,7 +2893,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 922
+Content-Length: 923
 
 {
   "code" : "200",
@@ -2907,7 +2907,7 @@ Content-Length: 922
       "content" : "SSAFY 9기 합격했습니다!!",
       "likeCount" : 3,
       "commentCount" : 2,
-      "createdAt" : "2023-09-24T16:23:04.130777",
+      "createdAt" : "2023-09-24T18:56:17.696512",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -2919,7 +2919,7 @@ Content-Length: 922
       "content" : "열심히 SSAFY 9기를 수료하시면 취업에 성공하실겁니다.",
       "likeCount" : 102,
       "commentCount" : 33,
-      "createdAt" : "2023-09-24T16:23:04.13078",
+      "createdAt" : "2023-09-24T18:56:17.696515",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -3111,7 +3111,7 @@ Content-Length: 954
       "content" : "역시 B형 특강을 열심히 듣는게 맞나요?",
       "likeCount" : 5,
       "commentCount" : 14,
-      "createdAt" : "2023-09-24T16:23:04.130758",
+      "createdAt" : "2023-09-24T18:56:17.696493",
       "nickname" : "익명",
       "anonymity" : true,
       "thumbnail" : "썸네일 URL"
@@ -3123,7 +3123,7 @@ Content-Length: 954
       "content" : "저도 싸피에서 교육들으면 개발실력 엄청 오르겠죠?",
       "likeCount" : 11,
       "commentCount" : 29,
-      "createdAt" : "2023-09-24T16:23:04.130744",
+      "createdAt" : "2023-09-24T18:56:17.696473",
       "nickname" : "이용준",
       "anonymity" : false,
       "thumbnail" : "썸네일 URL"
@@ -3306,7 +3306,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 1231
+Content-Length: 1233
 
 {
   "code" : "200",
@@ -3316,7 +3316,7 @@ Content-Length: 1231
       "commentId" : 1,
       "content" : "반가워요",
       "likeCount" : 3,
-      "createdAt" : "2023-09-24T16:23:04.127953",
+      "createdAt" : "2023-09-24T18:56:17.693823",
       "anonymity" : true,
       "modified" : false,
       "liked" : true,
@@ -3334,7 +3334,7 @@ Content-Length: 1231
         "commentId" : 1,
         "content" : "안녕하세요",
         "likeCount" : 10,
-        "createdAt" : "2023-09-24T16:23:04.1274",
+        "createdAt" : "2023-09-24T18:56:17.693243",
         "anonymity" : false,
         "modified" : false,
         "liked" : false,
@@ -4787,8 +4787,8 @@ Host: api.ssafsound.com
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Max-Age=2629744; Expires=Tue, 24 Oct 2023 17:52:07 GMT; Secure; HttpOnly
-Set-Cookie: refreshToken=syJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IsdfserwetweSflKxwRJeSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/auth/reissue; Max-Age=2629744; Expires=Tue, 24 Oct 2023 17:52:07 GMT; Secure; HttpOnly
+Set-Cookie: accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/; Max-Age=2629744; Expires=Tue, 24 Oct 2023 20:25:21 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=syJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IsdfserwetweSflKxwRJeSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c; Path=/auth/reissue; Max-Age=2629744; Expires=Tue, 24 Oct 2023 20:25:21 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 415
 
@@ -6038,7 +6038,7 @@ Content-Length: 379
   "data" : {
     "portfolioElement" : {
       "selfIntroduction" : "자기소개 하겠습니다.",
-      "skills" : [ "Android", "Java" ],
+      "skills" : [ "Java", "Android" ],
       "memberLinks" : [ {
         "linkName" : "velog",
         "path" : "http://test-link1"
@@ -6183,13 +6183,13 @@ Content-Length: 379
   "data" : {
     "portfolioElement" : {
       "selfIntroduction" : "자기소개 하겠습니다.",
-      "skills" : [ "Java", "Android" ],
+      "skills" : [ "Android", "Java" ],
       "memberLinks" : [ {
-        "linkName" : "t-story",
-        "path" : "http://test-link2"
-      }, {
         "linkName" : "velog",
         "path" : "http://test-link1"
+      }, {
+        "linkName" : "t-story",
+        "path" : "http://test-link2"
       } ]
     }
   }
@@ -8402,7 +8402,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 1707
+Content-Length: 1726
 
 {
   "code" : "200",
@@ -8449,7 +8449,8 @@ Content-Length: 1707
     },
     "scrapCount" : 1,
     "scraped" : true,
-    "matchStatus" : "INITIAL"
+    "matchStatus" : "INITIAL",
+    "mine" : true
   }
 }</code></pre>
 </div>
@@ -8615,6 +8616,11 @@ Content-Length: 1707
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.scraped</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">조회자 리크루트 스크랩 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.mine</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내가 작성한 리크루트 여부</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.scrapCount</code></p></td>
@@ -8998,7 +9004,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 890
+Content-Length: 892
 
 {
   "code" : "200",
@@ -9023,7 +9029,7 @@ Content-Length: 890
         "limit" : 4,
         "members" : [ {
           "nickname" : "KIM",
-          "major" : true
+          "isMajor" : true
         } ]
       }, {
         "recruitType" : "프론트엔드",
@@ -9146,7 +9152,7 @@ Content-Length: 890
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 닉네임</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].major</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].isMajor</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 전공 여부</p></td>
 </tr>
@@ -9254,7 +9260,7 @@ Content-Length: 973
         "limit" : 4,
         "members" : [ {
           "nickname" : "KIM",
-          "major" : true
+          "isMajor" : true
         } ]
       }, {
         "recruitType" : "프론트엔드",
@@ -9263,7 +9269,7 @@ Content-Length: 973
       } ],
       "mine" : false,
       "matchStatus" : "PENDING",
-      "appliedAt" : "2023-09-24T16:23:06.089121"
+      "appliedAt" : "2023-09-24T18:56:19.6344"
     } ],
     "nextCursor" : 1,
     "isLast" : true
@@ -9389,7 +9395,7 @@ Content-Length: 973
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 닉네임</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].major</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].isMajor</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 전공 여부</p></td>
 </tr>
@@ -9472,7 +9478,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 890
+Content-Length: 892
 
 {
   "code" : "200",
@@ -9497,7 +9503,7 @@ Content-Length: 890
         "limit" : 4,
         "members" : [ {
           "nickname" : "KIM",
-          "major" : true
+          "isMajor" : true
         } ]
       }, {
         "recruitType" : "프론트엔드",
@@ -9620,7 +9626,7 @@ Content-Length: 890
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 닉네임</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].major</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].isMajor</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 전공 여부</p></td>
 </tr>
@@ -9695,7 +9701,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 890
+Content-Length: 892
 
 {
   "code" : "200",
@@ -9720,7 +9726,7 @@ Content-Length: 890
         "limit" : 4,
         "members" : [ {
           "nickname" : "KIM",
-          "major" : true
+          "isMajor" : true
         } ]
       }, {
         "recruitType" : "프론트엔드",
@@ -9843,7 +9849,7 @@ Content-Length: 890
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 닉네임</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].major</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.recruits[].participants[].members[].isMajor</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">리크루트 참여자 전공 여부</p></td>
 </tr>
@@ -10434,7 +10440,7 @@ Content-Length: 988
         "limit" : 4,
         "members" : [ {
           "recruitApplicationId" : -1,
-          "joinedAt" : "2023-09-24T16:23:06.079949",
+          "joinedAt" : "2023-09-24T18:56:19.625076",
           "memberId" : 99,
           "nickname" : "KIM",
           "isMajor" : true,
@@ -10450,7 +10456,7 @@ Content-Length: 988
         "limit" : 3,
         "members" : [ {
           "recruitApplicationId" : 1,
-          "joinedAt" : "2023-09-24T16:23:06.087784",
+          "joinedAt" : "2023-09-24T18:56:19.633429",
           "memberId" : 99,
           "nickname" : "KIM",
           "isMajor" : true,
@@ -10616,7 +10622,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 864
+Content-Length: 863
 
 {
   "code" : "200",
@@ -10644,7 +10650,7 @@ Content-Length: 864
         "reply" : "취업 준비를 위해서 신청하게되었습니다.",
         "question" : "프로젝트에 참여하고자 하는 동기가 무엇인가요?",
         "liked" : false,
-        "appliedAt" : "2023-09-24T16:23:06.08678"
+        "appliedAt" : "2023-09-24T18:56:19.6322"
       } ]
     }
   }
@@ -10978,7 +10984,7 @@ Content-Length: 724
     "reply" : "취업 준비를 위해서 신청하게되었습니다.",
     "question" : "프로젝트에 참여하고자 하는 동기가 무엇인가요?",
     "liked" : false,
-    "appliedAt" : "2023-09-24T16:23:06.086711"
+    "appliedAt" : "2023-09-24T18:56:19.632126"
   }
 }</code></pre>
 </div>
@@ -11167,7 +11173,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 790
+Content-Length: 791
 
 {
   "code" : "200",
@@ -11194,7 +11200,7 @@ Content-Length: 790
       "reply" : "취업 준비를 위해서 신청하게되었습니다.",
       "question" : "프로젝트에 참여하고자 하는 동기가 무엇인가요?",
       "liked" : false,
-      "appliedAt" : "2023-09-24T16:23:06.08667"
+      "appliedAt" : "2023-09-24T18:56:19.632085"
     } ]
   }
 }</code></pre>
@@ -11410,7 +11416,7 @@ Content-Length: 724
     "reply" : "취업 준비를 위해서 신청하게되었습니다.",
     "question" : "프로젝트에 참여하고자 하는 동기가 무엇인가요?",
     "liked" : false,
-    "appliedAt" : "2023-09-24T16:23:06.086711"
+    "appliedAt" : "2023-09-24T18:56:19.632126"
   }
 }</code></pre>
 </div>
@@ -12143,7 +12149,7 @@ Content-Length: 741
       "likeCount" : 0,
       "liked" : false,
       "mine" : false,
-      "createdAt" : "2023-09-24T16:23:06.706771",
+      "createdAt" : "2023-09-24T18:56:20.207845",
       "deletedComment" : false,
       "modified" : false,
       "author" : {

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
@@ -244,7 +244,7 @@ public class RecruitControllerTest extends ControllerTest {
                                 fieldWithPath("limit").type(JsonFieldType.NUMBER).description("리크루트 모집 인원 제한 1명이상 10명 이하")
                             ).andWithPrefix("data.recruits[].participants[].members[].",
                                 fieldWithPath("nickname").type(JsonFieldType.STRING).description("리크루트 참여자 닉네임"),
-                                fieldWithPath("major").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
+                                fieldWithPath("isMajor").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
                             )
                         )
                 );
@@ -289,7 +289,7 @@ public class RecruitControllerTest extends ControllerTest {
                                 fieldWithPath("limit").type(JsonFieldType.NUMBER).description("리크루트 모집 인원 제한 1명이상 10명 이하")
                         ).andWithPrefix("data.recruits[].participants[].members[].",
                                 fieldWithPath("nickname").type(JsonFieldType.STRING).description("리크루트 참여자 닉네임"),
-                                fieldWithPath("major").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
+                                fieldWithPath("isMajor").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
                         )
                 )
             );
@@ -336,7 +336,7 @@ public class RecruitControllerTest extends ControllerTest {
                                         fieldWithPath("limit").type(JsonFieldType.NUMBER).description("리크루트 모집 인원 제한 1명이상 10명 이하")
                                 ).andWithPrefix("data.recruits[].participants[].members[].",
                                         fieldWithPath("nickname").type(JsonFieldType.STRING).description("리크루트 참여자 닉네임"),
-                                        fieldWithPath("major").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
+                                        fieldWithPath("isMajor").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
                                 )
                         )
                 );
@@ -385,7 +385,7 @@ public class RecruitControllerTest extends ControllerTest {
                                         fieldWithPath("limit").type(JsonFieldType.NUMBER).description("리크루트 모집 인원 제한 1명이상 10명 이하")
                                 ).andWithPrefix("data.recruits[].participants[].members[].",
                                         fieldWithPath("nickname").type(JsonFieldType.STRING).description("리크루트 참여자 닉네임"),
-                                        fieldWithPath("major").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
+                                        fieldWithPath("isMajor").type(JsonFieldType.BOOLEAN).description("리크루트 참여자 전공 여부")
                                 )
                         )
                 );

--- a/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/recruit/controller/RecruitControllerTest.java
@@ -146,6 +146,7 @@ public class RecruitControllerTest extends ControllerTest {
                                 fieldWithPath("author.ssafyMember").type(JsonFieldType.BOOLEAN).description("싸피 멤버 여부"),
                                 fieldWithPath("questions").type(JsonFieldType.ARRAY).description("리쿠르트 질문"),
                                 fieldWithPath("scraped").type(JsonFieldType.BOOLEAN).description("조회자 리크루트 스크랩 여부"),
+                                fieldWithPath("mine").type(JsonFieldType.BOOLEAN).description("내가 작성한 리크루트 여부"),
                                 fieldWithPath("scrapCount").type(JsonFieldType.NUMBER).description("리쿠르트 스크랩 갯수"),
                                 fieldWithPath("matchStatus").type(JsonFieldType.STRING).description("조회 유저 신청 상태")
                         ))

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/RecruitFixture.java
@@ -121,6 +121,7 @@ public class RecruitFixture {
             .author(new AuthorElement(memberFixture.createMember(), false))
             .scrapCount(1L)
             .scraped(true)
+            .mine(true)
             .matchStatus(MatchStatus.INITIAL.name())
             .build();
 


### PR DESCRIPTION
## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 리크루트 상세 조회 시 내가 쓴 글인지 여부 추가 
- 리크루트 참여자 목록 조회시 전공자여부 필드 major -> isMajor로 일괄되게 네이밍 수정 (프론트 요청사항) 

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
