### PR TITLE
hotfix: logout 요청 시 토큰 만료로 인한 비즈니스 로직 실패 케이스 수정

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -12,8 +12,6 @@ import com.ssafy.ssafsound.domain.member.domain.MemberToken;
 import com.ssafy.ssafsound.domain.member.dto.PostMemberReqDto;
 import com.ssafy.ssafsound.domain.member.service.MemberService;
 import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -24,6 +22,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/auth")

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -46,15 +46,14 @@ public class AuthController {
     }
 
     @DeleteMapping("/logout")
-    public EnvelopeResponse<Void> logout(@CookieValue(value = "accessToken", defaultValue = "") String accessToken,
-                                   @CookieValue(value = "refreshToken", defaultValue = "") String refreshToken,
-                                   HttpServletResponse response) {
-
-        if (!accessToken.equals("") || !refreshToken.equals("")) {
-            authService.deleteTokens(accessToken, refreshToken);
-            cookieProvider.setResponseWithCookies(response, null, null);
-        }
-        return EnvelopeResponse.<Void>builder().build();
+    public EnvelopeResponse<Void> logout(
+            @CookieValue(value = "accessToken") String accessToken,
+            @CookieValue(value = "refreshToken") String refreshToken,
+            HttpServletResponse response) {
+        authService.deleteTokens(accessToken, refreshToken);
+        cookieProvider.setResponseWithCookies(response, null, null);
+        return EnvelopeResponse.<Void>builder()
+                .build();
     }
 
     @GetMapping("/reissue")

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -78,7 +78,7 @@ public class AuthService {
 
         try {
             if (!accessToken.equals("")) {
-                AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaims(accessToken);
+                AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaimsByAccessToken(accessToken);
                 memberId = authenticatedMember.getMemberId();
             } else if (!refreshToken.equals("")) {
                 memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -20,6 +20,7 @@ import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import javax.servlet.http.HttpServletResponse;
 import java.time.Clock;
@@ -77,10 +78,10 @@ public class AuthService {
         Long memberId = null;
 
         try {
-            if (!accessToken.equals("")) {
+            if (StringUtils.hasText(accessToken)) {
                 AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaimsByAccessToken(accessToken);
                 memberId = authenticatedMember.getMemberId();
-            } else if (!refreshToken.equals("")) {
+            } else if (StringUtils.hasText(refreshToken)) {
                 memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
             }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -17,14 +17,17 @@ import com.ssafy.ssafsound.domain.member.exception.MemberErrorInfo;
 import com.ssafy.ssafsound.domain.member.exception.MemberException;
 import com.ssafy.ssafsound.domain.member.repository.MemberLoginLogRepository;
 import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpServletResponse;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
+@Slf4j
 public class AuthService {
 
     private final OauthProviderFactory oauthProviderFactory;
@@ -72,13 +75,21 @@ public class AuthService {
     @Transactional
     public void deleteTokens(String accessToken, String refreshToken) {
         Long memberId = null;
-        if (jwtTokenProvider.isValid(accessToken)) {
-            AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaims(accessToken);
-            memberId = authenticatedMember.getMemberId();
-        } else if (jwtTokenProvider.isValid(refreshToken)) {
-            memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
+
+        try {
+            if (!accessToken.equals("")) {
+                AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaims(accessToken);
+                memberId = authenticatedMember.getMemberId();
+            } else if (!refreshToken.equals("")) {
+                memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
+            }
+
+            if (Objects.nonNull(memberId)) {
+                memberTokenRepository.deleteById(memberId);
+            }
+        } catch (AuthException e) {
+            log.debug("유효하지 않은 토큰입니다.");
         }
-        if(memberId != null) memberTokenRepository.deleteById(memberId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -1,12 +1,17 @@
 package com.ssafy.ssafsound.domain.auth.service.token;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
-import com.ssafy.ssafsound.domain.auth.exception.AuthException;
 import com.ssafy.ssafsound.domain.auth.exception.AuthErrorInfo;
-import io.jsonwebtoken.*;
+import com.ssafy.ssafsound.domain.auth.exception.AuthException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import io.jsonwebtoken.security.Keys;
+
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
@@ -78,7 +83,10 @@ public class JwtTokenProvider {
                     .getBody();
         } catch (ExpiredJwtException e) {
             throw new AuthException(AuthErrorInfo.AUTH_TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorInfo.AUTH_TOKEN_INVALID);
         }
+
         Long memberId = claims.get("memberId", Long.class);
         String memberRole = claims.get("memberRole", String.class);
 

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/token/JwtTokenProvider.java
@@ -68,13 +68,13 @@ public class JwtTokenProvider {
         return claims.get("memberId", Long.class);
     }
 
-    public AuthenticatedMember getParsedClaims(String token) {
+    public AuthenticatedMember getParsedClaimsByAccessToken(String accessToken) {
         Claims claims;
         try {
             claims = Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
-                    .parseClaimsJws(token)
+                    .parseClaimsJws(accessToken)
                     .getBody();
         } catch (ExpiredJwtException e) {
             throw new AuthException(AuthErrorInfo.AUTH_TOKEN_EXPIRED);

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/validator/AuthenticationArgumentResolver.java
@@ -24,11 +24,11 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-        String token = AuthorizationExtractor.extractToken("accessToken", request);
-        if (token == null && request.getMethod().equals("GET")) {
+        String accessToken = AuthorizationExtractor.extractToken("accessToken", request);
+        if (accessToken == null && request.getMethod().equals("GET")) {
             return AuthenticatedMember.builder().build();
         }
 
-        return jwtTokenProvider.getParsedClaims(token);
+        return jwtTokenProvider.getParsedClaimsByAccessToken(accessToken);
     }
 }


### PR DESCRIPTION
## Issues

- #258 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- accessToken parseClaims 과정에서 발생할 수 있는 예외 케이스를 try - catch를 통해 잡았습니다.
- 어떠한 케이스에도 로그아웃 요청 시, Cookie Setting을 비울 수 있도록 코드를 리팩토링 했습니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타
try - catch 리팩토링 코드 보시면서 의견 주신다면 감사합니다.

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
