### PR TITLE
feat: 멤버 회원가입 시, 필수 약관 비즈니스 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,8 @@ jacocoTestCoverageVerification {
                         'com.ssafy.ssafsound.domain.auth.util.**',
                         'com.ssafy.ssafsound.domain.auth.service.token.**',
                         'com.ssafy.ssafsound.domain.QBaseTimeEntity',
-                        'com.ssafy.ssafsound.domain.chat.service.*Service']
+                        'com.ssafy.ssafsound.domain.chat.service.*Service',
+                        'com.ssafy.ssafsound.domain.term.service.*Service']
         }
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -79,7 +79,7 @@ public class MemberController {
             @Authentication AuthenticatedMember authenticatedMember,
             @Valid @RequestBody PostMemberInfoReqDto postMemberInfoReqDto) {
         return EnvelopeResponse.<GetMemberResDto>builder()
-                .data(memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto))
+                .data(memberService.registerMemberInformation(authenticatedMember.getMemberId(), postMemberInfoReqDto))
                 .build();
     }
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
@@ -34,7 +34,7 @@ public class PostMemberInfoReqDto {
     private String campus;
 
     @Builder.Default
-    private Set<Integer> termSequences = new HashSet<>();
+    private Set<Long> termIds = new HashSet<>();
 
     @JsonIgnore
     public boolean isNotSemesterPresent() {

--- a/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/dto/PostMemberInfoReqDto.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.HashSet;
+import java.util.Set;
 
 @Builder
 @AllArgsConstructor
@@ -30,6 +32,9 @@ public class PostMemberInfoReqDto {
     private Integer semester;
 
     private String campus;
+
+    @Builder.Default
+    private Set<Integer> termSequences = new HashSet<>();
 
     @JsonIgnore
     public boolean isNotSemesterPresent() {

--- a/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/exception/MemberErrorInfo.java
@@ -15,7 +15,8 @@ public enum MemberErrorInfo {
     SEMESTER_NOT_FOUND("713", "SSAFY Member 등록 또는 기수 수정 시, 기수 값은 필수입니다."),
     MEMBER_PROFILE_SECRET("714", "멤버의 프로필 공개 여부를 확인하세요"),
     MEMBER_NOT_SSAFY("715", "싸피생이 아닙니다."),
-    MEMBER_DELETED("716", "탈퇴한 회원입니다.");
+    MEMBER_DELETED("716", "탈퇴한 회원입니다."),
+    MEMBER_INPUT_INFORMATION_FAIL("717", "약관에 동의하셔야 합니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -22,6 +22,7 @@ import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
+import com.ssafy.ssafsound.domain.term.repository.TermRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +44,7 @@ public class MemberService {
     private final MemberProfileRepository memberProfileRepository;
     private final MemberSkillRepository memberSkillRepository;
     private final MemberLinkRepository memberLinkRepository;
+    private final TermRepository termRepository;
     private final MetaDataConsumer metaDataConsumer;
     private final MemberConstantProvider memberConstantProvider;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -91,6 +94,8 @@ public class MemberService {
 
         if(existNickname) {
             throw new MemberException(MemberErrorInfo.MEMBER_NICKNAME_DUPLICATION);
+        } else if (isNotAgreedRequiredTerms(postMemberInfoReqDto.getTermSequences())) {
+            throw new MemberException(MemberErrorInfo.MEMBER_INPUT_INFORMATION_FAIL);
         }
 
         Member member = memberRepository.findById(authenticatedMember.getMemberId())
@@ -351,5 +356,11 @@ public class MemberService {
                 .member(member)
                 .build();
         memberTokenRepository.save(memberToken);
+    }
+
+    private boolean isNotAgreedRequiredTerms(Set<Integer> termSequences) {
+        Integer size = termRepository.getSizeByRequiredTerm();
+
+        return size != termSequences.size();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -361,13 +361,13 @@ public class MemberService {
         memberTokenRepository.save(memberToken);
     }
 
-    private boolean isNotAgreedRequiredTerms(Member member, Set<Long> termSequences) {
+    private boolean isNotAgreedRequiredTerms(Member member, Set<Long> termIds) {
         List<Term> terms = termRepository.getRequiredTerms();
         boolean allIdsExistInTermSequences = terms.stream()
                 .map(Term::getId)
-                .allMatch(termSequences::contains);
+                .allMatch(termIds::contains);
 
-        if (terms.size() != termSequences.size()) {
+        if (terms.size() != termIds.size()) {
             return true;
         } else if (!allIdsExistInTermSequences) {
             return true;

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -92,10 +92,10 @@ public class MemberService {
 
     @Transactional
     public GetMemberResDto registerMemberInformation(
-            AuthenticatedMember authenticatedMember,
+            Long memberId,
             PostMemberInfoReqDto postMemberInfoReqDto) {
         boolean existNickname = memberRepository.existsByNickname(postMemberInfoReqDto.getNickname());
-        Member member = memberRepository.findById(authenticatedMember.getMemberId())
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
         if(existNickname) {

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -22,6 +22,7 @@ import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
+import com.ssafy.ssafsound.domain.term.domain.Term;
 import com.ssafy.ssafsound.domain.term.repository.TermRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -94,7 +95,7 @@ public class MemberService {
 
         if(existNickname) {
             throw new MemberException(MemberErrorInfo.MEMBER_NICKNAME_DUPLICATION);
-        } else if (isNotAgreedRequiredTerms(postMemberInfoReqDto.getTermSequences())) {
+        } else if (isNotAgreedRequiredTerms(postMemberInfoReqDto.getTermIds())) {
             throw new MemberException(MemberErrorInfo.MEMBER_INPUT_INFORMATION_FAIL);
         }
 
@@ -358,9 +359,18 @@ public class MemberService {
         memberTokenRepository.save(memberToken);
     }
 
-    private boolean isNotAgreedRequiredTerms(Set<Integer> termSequences) {
-        Integer size = termRepository.getSizeByRequiredTerm();
+    private boolean isNotAgreedRequiredTerms(Set<Long> termSequences) {
+        List<Term> terms = termRepository.getRequiredTerms();
+        boolean allIdsExistInTermSequences = terms.stream()
+                .map(Term::getId)
+                .allMatch(termSequences::contains);
 
-        return size != termSequences.size();
+        if (terms.size() != termSequences.size()) {
+            return true;
+        } else if (!allIdsExistInTermSequences) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/term/controller/TermController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/controller/TermController.java
@@ -1,0 +1,14 @@
+package com.ssafy.ssafsound.domain.term.controller;
+
+import com.ssafy.ssafsound.domain.term.service.TermService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/terms")
+@RequiredArgsConstructor
+public class TermController {
+
+    private final TermService termService;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/term/controller/TermController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/controller/TermController.java
@@ -1,7 +1,10 @@
 package com.ssafy.ssafsound.domain.term.controller;
 
+import com.ssafy.ssafsound.domain.term.dto.GetTermsResDto;
 import com.ssafy.ssafsound.domain.term.service.TermService;
+import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class TermController {
 
     private final TermService termService;
+
+    @GetMapping
+    public EnvelopeResponse<GetTermsResDto> getTerms() {
+        return EnvelopeResponse.<GetTermsResDto>builder()
+                .data(termService.getTerms())
+                .build();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/term/domain/MemberTermAgreement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/domain/MemberTermAgreement.java
@@ -15,6 +15,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity(name = "member_term_agreement")
 @Getter
@@ -35,4 +37,10 @@ public class MemberTermAgreement extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public static List<MemberTermAgreement> ofMemberAndTerms(Member member, List<Term> terms) {
+        return terms.stream()
+                .map(term -> MemberTermAgreement.builder().member(member).term(term).build())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/term/domain/MemberTermAgreement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/domain/MemberTermAgreement.java
@@ -1,0 +1,38 @@
+package com.ssafy.ssafsound.domain.term.domain;
+
+import com.ssafy.ssafsound.domain.BaseTimeEntity;
+import com.ssafy.ssafsound.domain.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity(name = "member_term_agreement")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberTermAgreement extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "member_term_agreement_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/term/domain/Term.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/domain/Term.java
@@ -26,7 +26,7 @@ public class Term extends BaseTimeEntity {
     private Long id;
 
     @Column
-    private String contents;
+    private String content;
 
     @Column
     private String name;

--- a/src/main/java/com/ssafy/ssafsound/domain/term/domain/Term.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/domain/Term.java
@@ -1,0 +1,44 @@
+package com.ssafy.ssafsound.domain.term.domain;
+
+import com.ssafy.ssafsound.domain.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+
+@Entity(name="term")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Term extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "term_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String contents;
+
+    @Column
+    private String name;
+
+    @Column
+    @Builder.Default
+    private Boolean usedYN = true;
+
+    @Column
+    @Builder.Default
+    private Boolean requiredYN = false;
+
+    @Column
+    private Integer sequence;
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/term/domain/Term.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/domain/Term.java
@@ -33,7 +33,7 @@ public class Term extends BaseTimeEntity {
 
     @Column
     @Builder.Default
-    private Boolean usedYN = true;
+    private Boolean usedYN = false;
 
     @Column
     @Builder.Default

--- a/src/main/java/com/ssafy/ssafsound/domain/term/domain/TermElement.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/domain/TermElement.java
@@ -1,0 +1,33 @@
+package com.ssafy.ssafsound.domain.term.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TermElement {
+
+    private Long termId;
+
+    private String termName;
+
+    private String content;
+
+    private Boolean requiredYN;
+
+    private Integer sequence;
+
+    public static TermElement from(Term term) {
+        return TermElement.builder()
+                .termId(term.getId())
+                .termName(term.getName())
+                .content(term.getContent())
+                .requiredYN(term.getRequiredYN())
+                .sequence(term.getSequence())
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/term/dto/GetTermsResDto.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/dto/GetTermsResDto.java
@@ -1,0 +1,19 @@
+package com.ssafy.ssafsound.domain.term.dto;
+
+import com.ssafy.ssafsound.domain.term.domain.TermElement;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class GetTermsResDto {
+    List<TermElement> termElements;
+
+    public static GetTermsResDto fromTermElements(List<TermElement> termElements) {
+        return GetTermsResDto.builder()
+                .termElements(termElements)
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/term/repository/MemberTermAgreementRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/repository/MemberTermAgreementRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.term.repository;
+
+import com.ssafy.ssafsound.domain.term.domain.MemberTermAgreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberTermAgreementRepository extends JpaRepository<MemberTermAgreement, Long> {
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/repository/TermRepository.java
@@ -23,4 +23,12 @@ public class TermRepository {
                 .fetch();
 
     }
+
+    public Integer getSizeByRequiredTerm() {
+        return jpaQueryFactory
+                .selectFrom(term)
+                .where(term.usedYN.eq(true), term.requiredYN.eq(true))
+                .fetch()
+                .size();
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/repository/TermRepository.java
@@ -24,11 +24,10 @@ public class TermRepository {
 
     }
 
-    public Integer getSizeByRequiredTerm() {
+    public List<Term> getRequiredTerms() {
         return jpaQueryFactory
                 .selectFrom(term)
                 .where(term.usedYN.eq(true), term.requiredYN.eq(true))
-                .fetch()
-                .size();
+                .fetch();
     }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/repository/TermRepository.java
@@ -1,0 +1,26 @@
+package com.ssafy.ssafsound.domain.term.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssafy.ssafsound.domain.term.domain.Term;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.ssafy.ssafsound.domain.term.domain.QTerm.term;
+
+@Repository
+@RequiredArgsConstructor
+public class TermRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Term> getTerms() {
+        return jpaQueryFactory
+                .selectFrom(term)
+                .where(term.usedYN.eq(true))
+                .orderBy(term.sequence.asc())
+                .fetch();
+
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/term/service/TermService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/service/TermService.java
@@ -1,9 +1,25 @@
 package com.ssafy.ssafsound.domain.term.service;
 
+import com.ssafy.ssafsound.domain.term.domain.TermElement;
+import com.ssafy.ssafsound.domain.term.dto.GetTermsResDto;
+import com.ssafy.ssafsound.domain.term.repository.TermRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TermService {
+
+    private final TermRepository termRepository;
+
+    @Transactional(readOnly = true)
+    public GetTermsResDto getTerms() {
+        return GetTermsResDto.fromTermElements(termRepository
+                .getTerms().stream()
+                .map(TermElement::from)
+                .collect(Collectors.toList()));
+    }
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/term/service/TermService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/term/service/TermService.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafsound.domain.term.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TermService {
+}

--- a/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
@@ -13,6 +13,9 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.payload.RequestFieldsSnippet;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static com.ssafy.ssafsound.global.docs.snippet.CookieDescriptionSnippet.requestCookieAccessTokenMandatory;
 import static com.ssafy.ssafsound.global.docs.snippet.CookieDescriptionSnippet.requestCookieAccessTokenNeedless;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,7 +55,8 @@ class MemberControllerTest extends ControllerTest {
                 fieldWithPath("ssafyMember").description("싸피인 여부"),
                 fieldWithPath("isMajor").description("전공자 여부"),
                 fieldWithPath("semester").optional().description("싸피 기수"),
-                fieldWithPath("campus").optional().description("캠퍼스 이름")
+                fieldWithPath("campus").optional().description("캠퍼스 이름"),
+                fieldWithPath("termIds").description("필수 약관 동의 아이디값")
         );
     }
 
@@ -160,6 +164,7 @@ class MemberControllerTest extends ControllerTest {
                 .nickname("james")
                 .ssafyMember(false)
                 .isMajor(true)
+                .termIds(new HashSet<>(Set.of(1L, 2L, 3L)))
                 .build();
 
         restDocs

--- a/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/controller/MemberControllerTest.java
@@ -56,7 +56,7 @@ class MemberControllerTest extends ControllerTest {
                 fieldWithPath("isMajor").description("전공자 여부"),
                 fieldWithPath("semester").optional().description("싸피 기수"),
                 fieldWithPath("campus").optional().description("캠퍼스 이름"),
-                fieldWithPath("termIds").description("필수 약관 동의 아이디값")
+                fieldWithPath("termIds").description("필수 약관 동의 아이디 값")
         );
     }
 

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -18,6 +18,7 @@ import com.ssafy.ssafsound.domain.meta.domain.MajorTrack;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
+import com.ssafy.ssafsound.domain.term.repository.TermRepository;
 import com.ssafy.ssafsound.global.util.fixture.MemberFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,8 @@ class MemberServiceTest {
     private MemberLinkRepository memberLinkRepository;
     @Mock
     private MemberSkillRepository memberSkillRepository;
+    @Mock
+    private TermRepository termRepository;
     @Mock
     private MetaDataConsumer metaDataConsumer;
     @Mock
@@ -301,6 +304,7 @@ class MemberServiceTest {
         PostMemberInfoReqDto postMemberInfoReqDto = memberFixture.createPostGeneralMemberInfoReqDto();
         given(memberRepository.existsByNickname(postMemberInfoReqDto.getNickname())).willReturn(false);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.empty());
+        given(termRepository.getSizeByRequiredTerm()).willReturn(postMemberInfoReqDto.getTermSequences().size());
 
         //when, then
         assertThrows(MemberException.class,
@@ -309,6 +313,7 @@ class MemberServiceTest {
         //verify
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
         verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());
+        verify(termRepository, times(1)).getSizeByRequiredTerm();
     }
 
     @Test
@@ -320,6 +325,7 @@ class MemberServiceTest {
         PostMemberInfoReqDto postMemberInfoReqDto = memberFixture.createPostGeneralMemberInfoReqDto();
         given(memberRepository.existsByNickname(postMemberInfoReqDto.getNickname())).willReturn(false);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
+        given(termRepository.getSizeByRequiredTerm()).willReturn(postMemberInfoReqDto.getTermSequences().size());
 
         //when
         GetMemberResDto response = memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto);
@@ -330,6 +336,7 @@ class MemberServiceTest {
         //verify
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
         verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());
+        verify(termRepository, times(1)).getSizeByRequiredTerm();
     }
 
     @Test

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -18,6 +18,7 @@ import com.ssafy.ssafsound.domain.meta.domain.MajorTrack;
 import com.ssafy.ssafsound.domain.meta.domain.MetaData;
 import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
+import com.ssafy.ssafsound.domain.term.repository.MemberTermAgreementRepository;
 import com.ssafy.ssafsound.domain.term.repository.TermRepository;
 import com.ssafy.ssafsound.global.util.fixture.MemberFixture;
 import com.ssafy.ssafsound.global.util.fixture.TermFixture;
@@ -54,6 +55,8 @@ class MemberServiceTest {
     private MemberSkillRepository memberSkillRepository;
     @Mock
     private TermRepository termRepository;
+    @Mock
+    private MemberTermAgreementRepository memberTermAgreementRepository;
     @Mock
     private MetaDataConsumer metaDataConsumer;
     @Mock
@@ -306,8 +309,6 @@ class MemberServiceTest {
         PostMemberInfoReqDto postMemberInfoReqDto = memberFixture.createPostGeneralMemberInfoReqDto();
         given(memberRepository.existsByNickname(postMemberInfoReqDto.getNickname())).willReturn(false);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.empty());
-        given(termRepository.getRequiredTerms())
-                .willReturn(termFixture.createTerms(postMemberInfoReqDto.getTermIds()));
 
         //when, then
         assertThrows(MemberException.class,
@@ -316,7 +317,6 @@ class MemberServiceTest {
         //verify
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
         verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());
-        verify(termRepository, times(1)).getRequiredTerms();
     }
 
     @Test
@@ -340,6 +340,7 @@ class MemberServiceTest {
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
         verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());
         verify(termRepository, times(1)).getRequiredTerms();
+        verify(memberTermAgreementRepository, times(1)).saveAll(any());
     }
 
     @Test

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -295,7 +295,7 @@ class MemberServiceTest {
 
         //when, then
         assertThrows(MemberException.class,
-                () -> memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto));
+                () -> memberService.registerMemberInformation(authenticatedMember.getMemberId(), postMemberInfoReqDto));
 
         //verify
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
@@ -312,7 +312,7 @@ class MemberServiceTest {
 
         //when, then
         assertThrows(MemberException.class,
-                () -> memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto));
+                () -> memberService.registerMemberInformation(authenticatedMember.getMemberId(), postMemberInfoReqDto));
 
         //verify
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
@@ -331,7 +331,8 @@ class MemberServiceTest {
         given(termRepository.getRequiredTerms()).willReturn(termFixture.createTerms(postMemberInfoReqDto.getTermIds()));
 
         //when
-        GetMemberResDto response = memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto);
+        GetMemberResDto response = memberService
+                .registerMemberInformation(authenticatedMember.getMemberId(), postMemberInfoReqDto);
 
         //then
         assertThat(response).usingRecursiveComparison().isEqualTo(GetMemberResDto.fromGeneralUser(member));
@@ -355,7 +356,8 @@ class MemberServiceTest {
         given(metaDataConsumer.getMetaData(any(), any())).willReturn(new MetaData(Campus.SEOUL));
 
         //when
-        GetMemberResDto response = memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto);
+        GetMemberResDto response = memberService
+                .registerMemberInformation(authenticatedMember.getMemberId(), postMemberInfoReqDto);
 
         //then
         assertThat(response).usingRecursiveComparison().isEqualTo(GetMemberResDto.fromSSAFYUser(member));

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -20,6 +20,7 @@ import com.ssafy.ssafsound.domain.meta.domain.MetaDataType;
 import com.ssafy.ssafsound.domain.meta.service.MetaDataConsumer;
 import com.ssafy.ssafsound.domain.term.repository.TermRepository;
 import com.ssafy.ssafsound.global.util.fixture.MemberFixture;
+import com.ssafy.ssafsound.global.util.fixture.TermFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +63,7 @@ class MemberServiceTest {
     @InjectMocks
     private MemberService memberService;
     MemberFixture memberFixture = new MemberFixture();
+    TermFixture termFixture = new TermFixture();
 
     @Test
     @DisplayName("새로운 Oauth Identifier가 주어졌다면 멤버를 저장하는데 성공합니다.")
@@ -304,7 +306,8 @@ class MemberServiceTest {
         PostMemberInfoReqDto postMemberInfoReqDto = memberFixture.createPostGeneralMemberInfoReqDto();
         given(memberRepository.existsByNickname(postMemberInfoReqDto.getNickname())).willReturn(false);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.empty());
-        given(termRepository.getSizeByRequiredTerm()).willReturn(postMemberInfoReqDto.getTermSequences().size());
+        given(termRepository.getRequiredTerms())
+                .willReturn(termFixture.createTerms(postMemberInfoReqDto.getTermIds()));
 
         //when, then
         assertThrows(MemberException.class,
@@ -313,7 +316,7 @@ class MemberServiceTest {
         //verify
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
         verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());
-        verify(termRepository, times(1)).getSizeByRequiredTerm();
+        verify(termRepository, times(1)).getRequiredTerms();
     }
 
     @Test
@@ -325,7 +328,7 @@ class MemberServiceTest {
         PostMemberInfoReqDto postMemberInfoReqDto = memberFixture.createPostGeneralMemberInfoReqDto();
         given(memberRepository.existsByNickname(postMemberInfoReqDto.getNickname())).willReturn(false);
         given(memberRepository.findById(authenticatedMember.getMemberId())).willReturn(Optional.of(member));
-        given(termRepository.getSizeByRequiredTerm()).willReturn(postMemberInfoReqDto.getTermSequences().size());
+        given(termRepository.getRequiredTerms()).willReturn(termFixture.createTerms(postMemberInfoReqDto.getTermIds()));
 
         //when
         GetMemberResDto response = memberService.registerMemberInformation(authenticatedMember, postMemberInfoReqDto);
@@ -336,7 +339,7 @@ class MemberServiceTest {
         //verify
         verify(memberRepository, times(1)).existsByNickname(postMemberInfoReqDto.getNickname());
         verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());
-        verify(termRepository, times(1)).getSizeByRequiredTerm();
+        verify(termRepository, times(1)).getRequiredTerms();
     }
 
     @Test

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
@@ -127,7 +127,7 @@ public class MemberFixture {
                 .ssafyMember(false)
                 .nickname("james")
                 .isMajor(true)
-                .termSequences(new HashSet<>(List.of(1, 2, 3)))
+                .termIds(new HashSet<>(Set.of(1L, 2L, 3L)))
                 .build();
     }
 

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
@@ -127,6 +127,7 @@ public class MemberFixture {
                 .ssafyMember(false)
                 .nickname("james")
                 .isMajor(true)
+                .termSequences(new HashSet<>(List.of(1, 2, 3)))
                 .build();
     }
 

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/TermFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/TermFixture.java
@@ -1,0 +1,27 @@
+package com.ssafy.ssafsound.global.util.fixture;
+
+import com.ssafy.ssafsound.domain.term.domain.Term;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class TermFixture {
+
+    public List<Term> createTerms(Set<Long> termIds) {
+        List<Term> terms = new ArrayList<>();
+
+        for (Long termId : termIds) {
+            terms.add(Term.builder()
+                    .id(termId)
+                    .name("이용 약관" + termId)
+                    .usedYN(true)
+                    .requiredYN(true)
+                    .sequence(1)
+                    .content("test" + termId)
+                    .build());
+        }
+
+        return terms;
+    }
+}


### PR DESCRIPTION
## Issues

- #271 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [x] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 약관 조회 API 호출 시, usedYN 즉 사용중인 약관들의 List를 Response로 제공합니다.
- 회원가입 이후, 정보 입력을 할 때, 동의한 약관 Id들에 대한 Request Body에 필드값을 추가로 넣었습니다.
  - 사용중인 필수 약관 동의들의 Id들이 Request Body로 넘어오지 않으면 예외가 발생합니다. (즉, 회원정보를 입력할 수 없음)
- 테스트 코드 및 Rest Docs를 수정했습니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
