### PR TITLE
refactor: 회원 탈퇴 시, 쿠키 삭제 및 비즈니스 로직 리팩토링

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -81,7 +81,7 @@ public class AuthController {
         AuthenticatedMember authenticatedMember = memberService.createMemberByOauthIdentifier(postMemberReqDto);
         CreateMemberTokensResDto createMemberTokensResDto = authService.createToken(authenticatedMember);
 
-        Member member = memberService.saveTokenByMember(authenticatedMember, createMemberTokensResDto);
+        Member member = memberService.saveTokenByMember(authenticatedMember.getMemberId(), createMemberTokensResDto);
 
         cookieProvider.setResponseWithCookies(
                 response,

--- a/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.ssafy.ssafsound.domain.member.controller;
 
 import com.ssafy.ssafsound.domain.auth.dto.AuthenticatedMember;
+import com.ssafy.ssafsound.domain.auth.service.CookieProvider;
 import com.ssafy.ssafsound.domain.auth.validator.Authentication;
 import com.ssafy.ssafsound.domain.member.dto.*;
 import com.ssafy.ssafsound.domain.member.service.MemberService;
@@ -8,6 +9,7 @@ import com.ssafy.ssafsound.global.common.response.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 @RestController
@@ -16,6 +18,7 @@ import javax.validation.Valid;
 public class MemberController {
 
     private final MemberService memberService;
+    private final CookieProvider cookieProvider;
 
     @GetMapping
     public EnvelopeResponse<GetMemberResDto> getMemberInformation(
@@ -165,9 +168,11 @@ public class MemberController {
     }
 
     @DeleteMapping
-    public EnvelopeResponse<Void> leaveMember(@Authentication AuthenticatedMember authenticatedMember) {
+    public EnvelopeResponse<Void> leaveMember(
+            @Authentication AuthenticatedMember authenticatedMember,
+            HttpServletResponse response) {
         memberService.leaveMember(authenticatedMember.getMemberId());
-
+        cookieProvider.setResponseWithCookies(response, null, null);
         return EnvelopeResponse.<Void>builder()
                 .build();
     }

--- a/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/repository/MemberRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByOauthIdentifier(String oauthIdentifier);
+    Member findByOauthIdentifier(String oauthIdentifier);
     
     boolean existsByNickname(String nickname);
 

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -75,13 +75,12 @@ public class MemberService {
 
     @Transactional
     public Member saveTokenByMember(
-        AuthenticatedMember authenticatedMember,
+        Long memberId,
         CreateMemberTokensResDto createMemberTokensResDto) {
-        Member member = memberRepository.findById(authenticatedMember.getMemberId())
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorInfo.MEMBER_NOT_FOUND_BY_ID));
 
-        Optional<MemberToken> memberTokenOptional = memberTokenRepository
-            .findById(authenticatedMember.getMemberId());
+        Optional<MemberToken> memberTokenOptional = memberTokenRepository.findById(memberId);
 
         memberTokenOptional.ifPresentOrElse(
             memberToken -> changeMemberTokens(memberToken, createMemberTokensResDto),

--- a/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/member/service/MemberService.java
@@ -204,6 +204,7 @@ public class MemberService {
         Member member = getMemberByMemberIdOrThrowException(memberId);
         member.setAccountStateDeleted();
         member.changeNickname("@" + member.getId());
+        memberTokenRepository.deleteById(memberId);
         applicationEventPublisher.publishEvent(new MemberLeavedEvent(member.getId()));
     }
 

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -138,53 +138,45 @@ class MemberServiceTest {
     void Given_Tokens_When_InitializeMember_Then_Success() {
         //given
         Member member = memberFixture.createInitializerMember();
-        AuthenticatedMember authenticatedMember = AuthenticatedMember.from(member);
-        given(memberTokenRepository.findById(authenticatedMember.getMemberId()))
-            .willReturn(Optional.empty());
-        given(memberRepository.findById(authenticatedMember.getMemberId()))
-            .willReturn(Optional.of(member));
+        given(memberTokenRepository.findById(member.getId())).willReturn(Optional.empty());
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
 
         //when
-        Member response = memberService
-            .saveTokenByMember(authenticatedMember, memberFixture.createMemberTokensResDto());
+        Member response = memberService.saveTokenByMember(member.getId(), memberFixture.createMemberTokensResDto());
 
         //then
         assertAll(
-            () -> assertEquals(response.getId(), authenticatedMember.getMemberId()),
-            () -> assertEquals(response.getRole().getRoleType(), authenticatedMember.getMemberRole())
+            () -> assertEquals(response.getId(), member.getId()),
+            () -> assertEquals(response.getRole().getRoleType(), member.getRole().getRoleType())
         );
 
 
         //verify
-        verify(memberTokenRepository, times(1))
-            .findById(authenticatedMember.getMemberId());
-        verify(memberRepository, times(1))
-            .findById(authenticatedMember.getMemberId());
+        verify(memberTokenRepository, times(1)).findById(member.getId());
+        verify(memberRepository, times(1)).findById(member.getId());
     }
 
     @Test
     @DisplayName("Member가 토큰을 발급한 적이 있다면 새로운 토큰들로 저장한다.")
     void Given_Tokens_When_JoinedMember_Then_SuccessExchangeTokens() {
         //given
-        MemberToken memberToken = memberFixture.createMemberToken();
-        AuthenticatedMember authenticatedMember = AuthenticatedMember.from(memberToken.getMember());
-        given(memberRepository.findById(authenticatedMember.getMemberId()))
-                .willReturn(Optional.of(memberToken.getMember()));
-        given(memberTokenRepository.findById(authenticatedMember.getMemberId()))
-                .willReturn(Optional.of(memberToken));
+        MemberToken memberToken = memberFixture.createMemberToken(memberFixture.createGeneralMember());
+        Long memberId = memberToken.getId();
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(memberToken.getMember()));
+        given(memberTokenRepository.findById(memberId)).willReturn(Optional.of(memberToken));
 
         //when
-        Member response = memberService.saveTokenByMember(authenticatedMember, memberFixture.createMemberTokensResDto());
+        Member response = memberService.saveTokenByMember(memberToken.getId(), memberFixture.createMemberTokensResDto());
 
         //then
         assertAll(
-                () -> assertEquals(response.getId(), authenticatedMember.getMemberId()),
-                () -> assertEquals(response.getRole().getRoleType(), authenticatedMember.getMemberRole())
+                () -> assertEquals(response.getId(), memberId),
+                () -> assertEquals(response.getRole().getRoleType(), memberToken.getMember().getRole().getRoleType())
         );
 
         //verify
-        verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());
-        verify(memberTokenRepository, times(1)).findById(authenticatedMember.getMemberId());
+        verify(memberRepository, times(1)).findById(memberId);
+        verify(memberTokenRepository, times(1)).findById(memberId);
     }
 
     @Test
@@ -192,11 +184,12 @@ class MemberServiceTest {
     void Given_Member_When_NotJoinedMember_Then_ThrowMemberException() {
         //given
         AuthenticatedMember authenticatedMember = AuthenticatedMember.from(memberFixture.createInitializerMember());
+        Long memberId = authenticatedMember.getMemberId();
         given(memberRepository.findById(any())).willReturn(Optional.empty());
 
         //when, then
         assertThrows(MemberException.class,
-                () -> memberService.saveTokenByMember(authenticatedMember, memberFixture.createMemberTokensResDto()));
+                () -> memberService.saveTokenByMember(memberId, memberFixture.createMemberTokensResDto()));
 
         //verify
         verify(memberRepository, times(1)).findById(authenticatedMember.getMemberId());

--- a/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/ssafsound/domain/member/service/MemberServiceTest.java
@@ -75,7 +75,7 @@ class MemberServiceTest {
         Member member = memberFixture.createGeneralMember();
         PostMemberReqDto postMemberReqDto = memberFixture.createPostMemberReqDto();
         given(memberRepository.findByOauthIdentifier(postMemberReqDto.getOauthIdentifier()))
-                .willReturn(Optional.empty());
+                .willReturn(null);
         given(memberRoleRepository.findByRoleType("user")).willReturn(Optional.of(member.getRole()));
         given(memberRepository.save(any())).willReturn(member);
 
@@ -102,7 +102,7 @@ class MemberServiceTest {
         Member member = memberFixture.createGeneralMember();
         PostMemberReqDto postMemberReqDto = memberFixture.createPostMemberReqDto();
         given(memberRepository.findByOauthIdentifier(postMemberReqDto.getOauthIdentifier()))
-                .willReturn(Optional.of(member));
+                .willReturn(member);
         //when
         AuthenticatedMember response = memberService.createMemberByOauthIdentifier(postMemberReqDto);
 
@@ -122,7 +122,7 @@ class MemberServiceTest {
         PostMemberReqDto postMemberReqDto = memberFixture.createPostMemberReqDto();
         Member member = memberFixture.createInitializerMember();
         given(memberRepository.findByOauthIdentifier(postMemberReqDto.getOauthIdentifier()))
-                .willReturn(Optional.of(member));
+                .willReturn(member);
 
         //when, then
         assertThrows(MemberException.class,

--- a/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
+++ b/src/test/java/com/ssafy/ssafsound/global/util/fixture/MemberFixture.java
@@ -284,9 +284,10 @@ public class MemberFixture {
             .build();
     }
 
-    public MemberToken createMemberToken() {
+    public MemberToken createMemberToken(Member member) {
         return MemberToken.builder()
-                .member(createGeneralMember())
+                .id(member.getId())
+                .member(member)
                 .accessToken(AuthFixture.accessToken)
                 .refreshToken(AuthFixture.refreshToken)
                 .build();


### PR DESCRIPTION
## Issues

- #277 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 회원 탈퇴 시, 쿠키 삭제 로직을 추가했습니다.
- 매개변수의 memberId만 필요한경우, 코드 리팩토링 및 테스트 코드를 수정했습니다.
- callback API 호출 시, member의 존재 유무에 따른 비즈니스 로직을 Indent Depth를 줄이기 위해 리팩토링 했습니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
