### PR TITLE
fix: 리크루트 마감 여부 false인 경우만 적용되도록 동적 쿼리 수정

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitDynamicQueryRepositoryImpl.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitDynamicQueryRepositoryImpl.java
@@ -73,12 +73,16 @@ public class RecruitDynamicQueryRepositoryImpl implements RecruitDynamicQueryRep
                 .where(
                         recruitCategoryEq(dto.getCategory()),
                         recruitTitleEq(dto.getKeyword()),
-                        recruit.finishedRecruit.eq(dto.isFinished()),
+                        notFinishedRecruit(dto.isFinished()),
                         recruitTypeContains(dto.getCategory(), dto.getRecruitTypes()),
                         recruitSkillContains(dto.getSkills())
                 );
 
         return PageableExecutionUtils.getPage(recruits, pageable, countQuery::fetchOne);
+    }
+
+    private static BooleanExpression notFinishedRecruit(boolean isFinished) {
+        return isFinished ? null : recruit.finishedRecruit.eq(false);
     }
 
     private JPAQuery<Recruit> findRecruitByGetRecruitsReqDto(RecruitPaging<? extends Number> dto) {
@@ -87,7 +91,7 @@ public class RecruitDynamicQueryRepositoryImpl implements RecruitDynamicQueryRep
                 .where(
                         recruitCategoryEq(dto.getCategory()),
                         recruitTitleEq(dto.getKeyword()),
-                        recruit.finishedRecruit.eq(dto.isFinished()),
+                        notFinishedRecruit(dto.isFinished()),
                         recruitTypeContains(dto.getCategory(), dto.getRecruitTypes()),
                         recruitSkillContains(dto.getSkills())
                 );


### PR DESCRIPTION
## Issues

- #285

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
- 리크루트 마감 여부가 true인 경우, 전체 엔티티가 조회되도록 동적 쿼리 수정 

