### PR TITLE
feat: 회원 탈퇴시 리크루트 일괄 삭제 및 리크루트 신청 일괄 취소

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/event/RecruitEventListener.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/event/RecruitEventListener.java
@@ -1,0 +1,27 @@
+package com.ssafy.ssafsound.domain.recruit.event;
+
+import com.ssafy.ssafsound.domain.event.MemberLeavedEvent;
+import com.ssafy.ssafsound.domain.recruit.repository.RecruitRepository;
+import com.ssafy.ssafsound.domain.recruitapplication.repository.RecruitApplicationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecruitEventListener {
+
+    private final RecruitRepository recruitRepository;
+    private final RecruitApplicationRepository recruitApplicationrepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void transactionalEventListenerAfterCommit(MemberLeavedEvent memberLeavedEvent) {
+        Long memberId = memberLeavedEvent.getMemberId();
+        log.info("{} 회원 탈퇴로 인한 등록 리크루트글 일괄 삭제 및 리크루트 신청 일괄 취소", memberLeavedEvent.getMemberId());
+        recruitRepository.deleteAllByMemberId(memberId);
+        recruitApplicationrepository.cancelAllByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/repository/RecruitRepository.java
@@ -4,6 +4,7 @@ import com.ssafy.ssafsound.domain.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -26,4 +27,8 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long>, Recruit
     @Modifying
     @Query(value = "update recruit r set r.finishedRecruit = true where r.endDateTime < :todayMaxTime")
     int expiredTimeOutRecruits(LocalDateTime todayMaxTime);
+
+    @Modifying
+    @Query(value = "update recruit r set r.deletedRecruit = true where r.member.id = :memberId")
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruitapplication/repository/RecruitApplicationRepository.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafsound.domain.recruitapplication.domain.RecruitApplication;
 import com.ssafy.ssafsound.domain.recruitapplication.dto.RecruitApplicationElement;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -47,4 +48,8 @@ public interface RecruitApplicationRepository extends JpaRepository<RecruitAppli
     void deleteByTypeNotIn(List<MetaData> recruitTypes);
 
     RecruitApplication findTopByRecruitIdAndMemberIdOrderByIdDesc(Long recruitId, Long memberId);
+
+    @Modifying
+    @Query(value = "update recruit_application ra set ra.matchStatus = com.ssafy.ssafsound.domain.recruitapplication.domain.MatchStatus.CANCEL where ra.member.id = :memberId")
+    void cancelAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
## Issues

- #287

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
- 회원 탈퇴시, 다른 회원들이 리크루트 사용에 지장이없도록 탈퇴유저가 작성한 리크루트 글 soft delete처리 및 리크루트 신청 일괄 취소
