### PR TITLE
fix: recruit 업데이트시, limitation값 반영되지 않는 오류 수정

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/recruit/service/RecruitService.java
@@ -111,8 +111,10 @@ public class RecruitService {
         }
 
         recruitLimitationRepository.deleteAllByRecruit(recruit);
-        recruit.setRecruitLimitations(recruitLimitations);
+
         recruit.update(recruitReqDto);
+        recruit.setRecruitLimitations(recruitLimitations);
+        recruitLimitationRepository.saveAll(recruitLimitations);
 
         List<MetaData> recruitTypes = recruitLimitations.stream()
                 .map(RecruitLimitation::getType)


### PR DESCRIPTION
## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 리크루트 업데이트 시, 리크루트 제한 사항 미반영으로 인한 업데이트 쿼리 추가 
- Cascade persist 대신 별도의 update 쿼리 사용 
