### PR TITLE
refactor: 멤버의 로그아웃 로직 리팩토링

### DIFF
--- a/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/controller/AuthController.java
@@ -47,11 +47,7 @@ public class AuthController {
     }
 
     @DeleteMapping("/logout")
-    public EnvelopeResponse<Void> logout(
-            @CookieValue(value = "accessToken", defaultValue = "") String accessToken,
-            @CookieValue(value = "refreshToken", defaultValue = "") String refreshToken,
-            HttpServletResponse response) {
-        authService.deleteTokens(accessToken, refreshToken);
+    public EnvelopeResponse<Void> logout(HttpServletResponse response) {
         cookieProvider.setResponseWithCookies(response, null, null);
         return EnvelopeResponse.<Void>builder()
                 .build();

--- a/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/ssafsound/domain/auth/service/AuthService.java
@@ -20,12 +20,9 @@ import com.ssafy.ssafsound.domain.member.repository.MemberTokenRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
-
 import javax.servlet.http.HttpServletResponse;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @Service
 @Slf4j
@@ -71,26 +68,6 @@ public class AuthService {
                 .accessToken(jwtTokenProvider.createAccessToken(authenticatedMember))
                 .refreshToken(jwtTokenProvider.createRefreshToken(authenticatedMember))
                 .build();
-    }
-
-    @Transactional
-    public void deleteTokens(String accessToken, String refreshToken) {
-        Long memberId = null;
-
-        try {
-            if (StringUtils.hasText(accessToken)) {
-                AuthenticatedMember authenticatedMember = jwtTokenProvider.getParsedClaimsByAccessToken(accessToken);
-                memberId = authenticatedMember.getMemberId();
-            } else if (StringUtils.hasText(refreshToken)) {
-                memberId = jwtTokenProvider.getMemberIdByRefreshToken(refreshToken);
-            }
-
-            if (Objects.nonNull(memberId)) {
-                memberTokenRepository.deleteById(memberId);
-            }
-        } catch (AuthException e) {
-            log.debug("유효하지 않은 토큰입니다.");
-        }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Issues

- #296 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 로그아웃 로직을 리팩토링합니다.

- 어떠한 이유로도 로그아웃 API 요청이 왔을때, 쿠키가 삭제되도록 리팩토링했습니다.
- 현재 .ssafsound.com domain 설정으로 인해 test.ssafsound.com 및 ssafsound.com 으로 oauth login을 진행했을때 브라우저에 쿠키가 생성됩니다.
- 로그아웃 로직에서 토큰 값에 대한 검증 후, memberId를 추출하여 memberToken을 삭제하는 로직이 존재했습니다. memberId가 테스트 서버 및 실 서버에서 체크됨에 따라 존재하지 않아 서버 에러가 발생하는 원인이 있었습니다.
- MemberToken은 One To One 관계임으로 최초 생성 후, 업데이트만 진행될 수 있게 위에서 언급한 삭제 로직을 제거했습니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->
